### PR TITLE
ci: fail build if clippy warnings are present

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,3 +22,5 @@ jobs:
       run: cargo test --verbose --features slow_tests
     - name: Format
       run: cargo fmt --check
+    - name: Clippy
+      run: cargo clippy -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,7 @@ capnpc = "0.19.0"
 
 [features]
 slow_tests = []
+
+[lints.clippy]
+new_without_default = "allow"
+expect_fun_call = "allow"

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -84,8 +84,10 @@ impl Cluster {
 
     /// Create a Cluster given a path to a config file.
     pub fn from_config(config: String) -> Result<Self, crate::commands::EmptyError> {
-        let mut args = crate::commands::Cli::default();
-        args.config = Some(config);
+        let args = crate::commands::Cli {
+            config: Some(config),
+            ..Default::default()
+        };
         let context = Arc::new(MgrContext::new(args));
         Self::new(context)
     }
@@ -283,10 +285,7 @@ impl Cluster {
 
 /// Given a list `pairs` of failover pairs, and a hostname `name`, return its partner, if one
 /// exists.
-fn get_failover_partner<'pairs>(
-    pairs: &'pairs Vec<Vec<String>>,
-    name: &str,
-) -> Option<&'pairs str> {
+fn get_failover_partner<'pairs>(pairs: &'pairs [Vec<String>], name: &str) -> Option<&'pairs str> {
     for pair in pairs.iter() {
         if name == pair[0] {
             return Some(&pair[1]);

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -21,17 +21,9 @@ pub struct MgrContext {
 
 impl MgrContext {
     pub fn new(args: crate::commands::Cli) -> Self {
-        let mut context = Self::default();
-        context.args = args;
-        context
-    }
-}
-
-impl Default for MgrContext {
-    fn default() -> MgrContext {
         MgrContext {
             out_stream: crate::LogStream::new_stdout(),
-            args: crate::commands::Cli::default(),
+            args,
         }
     }
 }
@@ -160,11 +152,11 @@ async fn manager_main(cluster: Arc<cluster::Cluster>) {
 /// This launches two "services".
 ///
 /// - A manager service which continuously monitors the state of the cluster.
-///     The monitoring service takes actions based on cluster status, such as migrating resources,
-///     fencing nodes, etc.
+///   The monitoring service takes actions based on cluster status, such as migrating resources,
+///   fencing nodes, etc.
 ///
 /// - A server that listens on a unix socket (/var/run/halo.socket) for
-///     commands from the command line interface.
+///   commands from the command line interface.
 pub fn main(cluster: cluster::Cluster) -> crate::commands::Result {
     let cluster = Arc::new(cluster);
 

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -145,7 +145,7 @@ impl TestEnvironment {
             .expect("Could not create cluster from config file");
 
         std::thread::spawn(move || {
-            if let Err(_) = crate::manager::main(cluster) {
+            if crate::manager::main(cluster).is_err() {
                 std::process::exit(1);
             }
         });


### PR DESCRIPTION
Also, fixes up already existing clippy warnings, and turns off some annoying warnings in the config file.