### PR TITLE
host: handle errors connecting to remote agent

### DIFF
--- a/src/halo_capnp.rs
+++ b/src/halo_capnp.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright 2025. Triad National Security, LLC.
 
-use std::{
-    cell::{Ref, RefCell},
-    env, io,
-};
+use std::{env, io};
 
 use {futures::AsyncReadExt, rustls::pki_types::ServerName};
 
@@ -189,59 +186,22 @@ fn prep_request(request: &mut OperationRequest, res: &Resource, op: ocf_resource
     }
 }
 
-/// A ClientWrapper manages a connection to a remote agent. It allows a set of tasks to share a
-/// connection, so that multiple resourcs can be managed without needing a separate connection per
-/// resource.
-///
-/// If a connection breaks, the ClientWrapper allows the set of tasks using that connection to
-/// collectively begin using a single new connection.
-pub struct ClientWrapper {
-    address: String,
-    inner: RefCell<Option<ocf_resource_agent::Client>>,
-}
+pub async fn get_client(address: &str) -> io::Result<ocf_resource_agent::Client> {
+    let stream = tokio::net::TcpStream::connect(address).await?;
+    stream.set_nodelay(true).expect("setting nodelay failed.");
 
-impl ClientWrapper {
-    pub fn new(address: String) -> Self {
-        Self {
-            address,
-            inner: RefCell::new(None),
-        }
-    }
+    let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
 
-    pub async fn get(&self) -> Ref<'_, ocf_resource_agent::Client> {
-        if self.inner.borrow().is_none() {
-            let client = self
-                .get_client()
-                .await
-                .expect("TODO: handle error creating client.");
-            let _ = self.inner.borrow_mut().insert(client);
-        }
+    let rpc_network = Box::new(twoparty::VatNetwork::new(
+        futures::io::BufReader::new(reader),
+        futures::io::BufWriter::new(writer),
+        rpc_twoparty_capnp::Side::Client,
+        Default::default(),
+    ));
+    let mut rpc_system = RpcSystem::new(rpc_network, None);
+    let client: ocf_resource_agent::Client = rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
 
-        Ref::map(self.inner.borrow(), |inner| inner.as_ref().unwrap())
-    }
+    tokio::task::spawn_local(rpc_system);
 
-    pub fn clear(&self) {
-        let _ = self.inner.borrow_mut().take();
-    }
-
-    async fn get_client(&self) -> io::Result<ocf_resource_agent::Client> {
-        let stream = tokio::net::TcpStream::connect(&self.address).await?;
-        stream.set_nodelay(true).expect("setting nodelay failed.");
-
-        let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
-
-        let rpc_network = Box::new(twoparty::VatNetwork::new(
-            futures::io::BufReader::new(reader),
-            futures::io::BufWriter::new(writer),
-            rpc_twoparty_capnp::Side::Client,
-            Default::default(),
-        ));
-        let mut rpc_system = RpcSystem::new(rpc_network, None);
-        let client: ocf_resource_agent::Client =
-            rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
-
-        tokio::task::spawn_local(rpc_system);
-
-        Ok(client)
-    }
+    Ok(client)
 }

--- a/src/host/observe.rs
+++ b/src/host/observe.rs
@@ -3,8 +3,6 @@
 
 //! Observe-only management of a cluster without high-availability.
 
-use std::cell::Ref;
-
 use futures::future;
 
 use crate::Cluster;
@@ -14,26 +12,19 @@ use super::*;
 #[allow(clippy::await_holding_refcell_ref)]
 impl Host {
     pub async fn observe(&self, cluster: &Cluster) {
-        let client = ClientWrapper::new(self.address().to_string());
-
         loop {
-            {
-                // Inner scope needed to ensure that all `client_ref`s are dropped before
-                // client.clear() below...
-                let client_ref = client.get().await;
+            let client = crate::halo_capnp::get_client(&self.address())
+                .await
+                .expect("TODO: handle error here.");
 
-                let futures: Vec<_> = cluster
-                    .host_home_resource_groups(self)
-                    .map(|rg| {
-                        self.observe_resource_group(cluster, rg.id(), Ref::clone(&client_ref))
-                    })
-                    .collect();
+            let futures: Vec<_> = cluster
+                .host_home_resource_groups(self)
+                .map(|rg| self.observe_resource_group(cluster, rg.id(), &client))
+                .collect();
 
-                let _ = future::join_all(futures).await;
-            }
+            let _ = future::join_all(futures).await;
 
             // Once all tasks exited (because an RPC error occurred), just wait a bit and try again:
-            client.clear();
             tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
         }
     }
@@ -42,10 +33,10 @@ impl Host {
         &self,
         cluster: &Cluster,
         rg: &str,
-        client: Ref<'_, ocf_resource_agent::Client>,
+        client: &ocf_resource_agent::Client,
     ) {
         let rg = cluster.get_resource_group(rg);
-        let err = rg.observe_loop(&client).await;
+        let err = rg.observe_loop(client).await;
         eprintln!("received error: {err:?}");
     }
 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -521,6 +521,14 @@ impl Resource {
             d.set_managed(managed);
         }
     }
+
+    pub fn set_error_recursive(&self, reason: String) {
+        for child in self.dependents.iter() {
+            child.set_error_recursive(reason.clone());
+        }
+
+        self.set_status(ResourceStatus::Error(reason));
+    }
 }
 
 /// The ordering on ResourceStatus is used to rank statuses from "worst" to "best". Statuses that


### PR DESCRIPTION
When an error is recieved while attempting to connect to the remote agent, it is not possible to continue normal management of the host's resources.

This introduces a new frameowrk for HA host management in which a separate management routine is used when a connection to the remote agent is not possible.

Previously, struct ClientWrapper had a get_client() method which was difficult to use, being fallible and async. (Well, it would've been fallible if it wasn't panicking on error....)

This method would have made proper management of the "disconnected" case difficult as all that logic would have to be interspersed within the same routine that did management assuming an alive connection.

Instead, this tries to get a client connection and then chooses the appropriate routine based on the outcome of that attempt.