### PR TITLE
fixup docs: developer_guide

### DIFF
--- a/docs/developer_guide.typ
+++ b/docs/developer_guide.typ
@@ -231,7 +231,7 @@ This code is in `src/host/ha/manage.rs`.
 
 Since this is the most complex part of HALO, and since any bugs in this code
 could result in service outages or double-started resources,
-I will attempt to explain how it works in detail in this section.
+this section makes a significant effort to explain how it works in detail.
 
 == Mutable state
 
@@ -248,7 +248,7 @@ a given time, and also that no resource is "forgotten about", never being manage
 When the HALO manager starts up, a single `ResourceToken` is created for each resource group
 in the cluster.
 (The name `ResourceToken` is slightly misleading because tokens correspond to `ResourceGroup`
-and not `Resource`, but I thought `ResourceGroupToken` would be too long....)
+and not `Resource`, but the name `ResourceGroupToken` would be too long....)
 This occurs in `Host::mint_resource_tokens()`.
 
 `ResourceToken`s can never be destroyed once created.

--- a/docs/developer_guide.typ
+++ b/docs/developer_guide.typ
@@ -168,7 +168,7 @@ This requirement holds even though we use `axum` within a single-threaded contex
 so the objects passed to `axum::serve()` will never actually be accessed
 from multiple threads.
 
-Thus, any of the objects in `HALO` that are reachable from the arguments passed
+Thus, any of the objects in HALO that are reachable from the arguments passed
 to `axum::serve()` must be thread-safe.
 Specifically `Cluster`, and the objects reachable from it--`Host`, `ResourceGroup`,
 and `Resource`--must be `Send + Sync`.
@@ -511,7 +511,7 @@ live in `tests/test_output/simple/`.
 When a test runs multiple agents (because the test is simulating a cluster with multiple nodes), the
 test ID is not suitable to uniquely identify the agents. A new unique identifier for the agents is
 needed for operations like fencing. When a test launches the agents, it can specify an optional
-unique ID per-agent. This agent ID is encoded in the path to the resource state files managed
+unique per-agent ID. This agent ID is encoded in the path to the resource state files managed
 by that agent, so that the test environment can tell which agent "owns" a given resource at a
 particular moment.
 

--- a/docs/developer_guide.typ
+++ b/docs/developer_guide.typ
@@ -52,7 +52,7 @@ the requested op.
 HALO uses an HTTP API to communicate between the admin CLI utility and the manager service.
 The client side implementation uses the
 #link("https://docs.rs/reqwest/latest/reqwest/")[reqwest]
-library, and the serve side uses the
+library, and the server side uses the
 #link("https://docs.rs/axum/latest/axum/")[axum]
 library.
 
@@ -175,7 +175,7 @@ and `Resource`--must be `Send + Sync`.
 
 The practical takeaway of this is that anywhere that interior mutability is
 required in any of those objects, a `Mutex` must be used, even though
-it would seem like a a `RefCell` should be sufficient.
+it would seem like a `RefCell` should be sufficient.
 Similarly, anywhere that multiple ownership is needed, an `Arc` must be used
 even though an `Rc` would seem sufficient.
 


### PR DESCRIPTION
This MR attempts to clean up any typos (and perhaps reword statements for readability) in the HALO developer documentation.