### PR TITLE
status: stable output order of params with --verbose

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -38,12 +38,17 @@ pub fn status(cli: &Cli, args: &StatusArgs) -> HandledResult<()> {
 
         if cli.verbose {
             print!(" [");
-            let mut params = res.parameters.iter();
-            if let Some((key, val)) = params.next() {
-                print!("{key}: {val}");
-                for (key, val) in params {
-                    print!("; {key}: {val}");
+            let mut first_one = true;
+            let mut params: Vec<_> = res.parameters.keys().collect();
+            params.sort();
+            for param in params {
+                if first_one {
+                    first_one = false;
+                } else {
+                    print!("; ");
                 }
+                let value = &res.parameters[param];
+                print!("{param}: {value}");
             }
             print!("]");
         }


### PR DESCRIPTION
"halo status verbose" prints the resource parameters, such as below, within square braces.  They are stored in a HashMap.

	iron2       (llnl/zpool)  Running on iron2 [pool: iron2]
	iron2/mdt1  (llnl/lustre) Running on iron2 [dataset: iron2/mdt1; mountpoint: /mnt/lustre/lobster-MDT0001; type: mdt]

The existing code iterates over the HashMap in a different order every time, so

	watch halo status --verbose

produces constant change even when the resource states and parameters are not changing.

Sort the parameters before printing them and their values to prevent this, making actual change easy to see.