### PR TITLE
status: align output columns

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -24,8 +24,8 @@ pub fn status(cli: &Cli, args: &StatusArgs) -> HandledResult<()> {
             continue;
         }
 
-        print!("{}\t", res.id);
-        print!("({}):\t", res.kind);
+        print!("{:<20}\t", res.id);
+        print!("({})\t", res.kind);
         print!("{}", res.status);
         match res.status.as_str() {
             "Running" => print!(" on {}", res.home_host),
@@ -58,6 +58,8 @@ pub fn status(cli: &Cli, args: &StatusArgs) -> HandledResult<()> {
 
         println!();
     }
+
+    println!();
 
     let mut abnormal = false;
     let mut connected_activated = String::new();


### PR DESCRIPTION
Since the resource name lengths vary significantly, the "\t" was not sufficient to align the output columns.

```
iron1/mgs	(llnl/lustre)   Running on iron1
iron2	(llnl/zpool)    Running on iron2
```

Add field widths to the print() calls so the output is aligned.

```
iron1/mgs               (llnl/lustre)   Running on iron1
iron2                   (llnl/zpool)    Running on iron2
```

Also, add a newline below the table of resources since the content below (Connected hosts, etc.) is two columns wide instead of 5 or more, and is different in kind (lists of hosts vs resources).