### PR TITLE
sysconfig/halo: create a sysconfig file with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,5 @@ To install and start the remote server:
 
 ## Configuration
 
-Besides using command-line arguments,
-the daemons can be configured via environment variables defined in `/etc/sysconfig/halo`.
-HALO recognizes the following variables:
-
-- `HALO_CONFIG` -- defines the location to search for the configuration file (default: `/etc/halo/halo.conf`).
-- `HALO_PORT` -- defines port for the daemon to listen on (default `8000`).
-- `HALO_NET` -- defines the network that the daemon listens on (default `192.168.1.0/24`).
-- `HALO_LOG` -- the log level for the manager and remote daemons. Default is "warn". Set to "debug" or "trace" for more output.
-
-When using TLS, HALO additionally will check `HALO_{CLIENT,SERVER}_{CERT,KEY}`.
+Besides using command-line arguments, the daemons can be configured via
+environment variables defined in `/etc/sysconfig/halo`.  See sysconfig/halo.

--- a/sysconfig/halo
+++ b/sysconfig/halo
@@ -1,0 +1,14 @@
+# Define the location to search for the configuration file
+# HALO_CONFIG=/etc/halo/halo.conf
+
+# Define port for the daemon to listen on
+# HALO_PORT=8000
+
+# Define the network that the daemon listens on
+# HALO_NET=192.168.1.0/24
+
+# The log level for the manager and remote daemons. Set to "debug" or "trace" for more output.
+# HALO_LOG=warn
+
+# When using TLS, HALO additionally will check below variables
+# HALO_{CLIENT,SERVER}_{CERT,KEY}


### PR DESCRIPTION
To be installed in sysconfig directory by rpm, after the software has been packaged.  In preparation for adding a specfile.