### PR TITLE
Support for more generic cluster configurations

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -113,12 +113,6 @@ impl Cluster {
         self.resource_groups.iter()
     }
 
-    pub fn resources(&self) -> impl Iterator<Item = &Resource> {
-        self.resource_groups
-            .iter()
-            .flat_map(|group| group.resources())
-    }
-
     pub fn host_home_resource_groups<'a>(
         &'a self,
         host: &'a Host,
@@ -197,8 +191,9 @@ impl Cluster {
 
         let new = Cluster::from_config2(&config, args.clone(), state, tls_args);
 
-        if new.resources().any(|res| res.count > 1) {
-            eprintln!("Config has shared resources, which are not yet supported.");
+        if new.resource_groups.iter().any(|rg| rg.root.count > 1) {
+            eprintln!("Config has a shared root resource, which is not supported.");
+            eprintln!("(Only child resources can be shared.)");
             return handled_error();
         }
 

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -84,7 +84,7 @@ impl Cluster {
             let ResourceId(cluster_rg_id) = cluster_rg.id();
 
             if let Some(managed) = state.delta.resources_managed.get(&cluster_rg_id) {
-                cluster_rg.set_managed(*managed);
+                cluster_rg.set_initial_managed(*managed);
                 unapplied_resources.remove(&cluster_rg_id);
             }
         }
@@ -202,7 +202,7 @@ impl Cluster {
         // If the cluster is running in "observe-only" mode, mark every resource group as unmanaged
         if !args.manage_resources {
             for rg in new.resource_groups() {
-                rg.set_managed(false);
+                rg.set_initial_managed(false);
             }
         }
 

--- a/src/host/ha.rs
+++ b/src/host/ha.rs
@@ -325,6 +325,7 @@ impl Host {
                     // Deactivate message: nothing to do because the remote is disconnected. No
                     // ability to stop resources even if they happened to be running on the remote.
                     HostCommand::Deactivate => {}
+                    HostCommand::Remanage(id) => self.remanage_resource_group(state, id),
                 },
                 HostMessage::TaskDone(id) => {
                     panic!("Unexpected message type 'None({id})' in client disconnected routine.")
@@ -368,6 +369,7 @@ impl Host {
                         HostCommand::Failback => self.do_failback(state, cluster),
                         HostCommand::Deactivate => self.deactivate(state),
                         HostCommand::Fence => self.admin_fence_request(state),
+                        HostCommand::Remanage(id) => self.remanage_resource_group(state, id),
                     };
 
                     tasks.push(Box::pin(self.receive_message()));
@@ -431,6 +433,16 @@ impl Host {
         unreachable!(
             "Tasks loop should not exit, a receive message task should always be registered."
         )
+    }
+
+    fn remanage_resource_group(&self, state: &mut HostState, which_one: String) {
+        for task in &state.outstanding_resource_tasks {
+            if task.id != which_one {
+                continue;
+            }
+
+            task.remanage.notify_one();
+        }
     }
 
     /// Deactivate this Host:
@@ -901,6 +913,11 @@ impl Host {
 
             _ = revoke.switch_host.notified() => {
                 self.send_message_to_self(token, Message::SwitchHost).await;
+                HostMessage::MessageFollows
+            }
+
+            _ = revoke.remanage.notified() => {
+                self.send_message_to_self(token, Message::CheckResourceGroup).await;
                 HostMessage::MessageFollows
             }
 

--- a/src/host/ha.rs
+++ b/src/host/ha.rs
@@ -668,11 +668,13 @@ impl Host {
 
     fn update_resource_groups_stopped(&self, cluster: &Cluster) {
         for rg in cluster.host_home_resource_groups(self) {
+            rg.remove_group_from_host(&self.id());
             rg.root
                 .set_status_recursive(ResourceStatus::Stopped, &self.id());
         }
 
         for rg in cluster.host_home_resource_groups(self.ha_failover_partner()) {
+            rg.remove_group_from_host(&self.id());
             rg.root
                 .set_status_recursive(ResourceStatus::Stopped, &self.id());
         }

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -62,6 +62,11 @@ pub enum HostCommand {
     /// deactivated.
     Deactivate,
     Fence,
+
+    /// Remanage a resource group whose ID is the given string. This requires the manager to forget
+    /// any knowledge on where the resource group may have been running, because it may have been
+    /// migrated.
+    Remanage(String),
 }
 
 #[derive(Debug)]
@@ -491,6 +496,10 @@ struct ResourceTaskCancel {
     /// A notification mechanism to tell a resource group management task to stop so that
     /// management can be handed over to the partner host.
     switch_host: Rc<Notify>,
+
+    /// A notification to tell the resource group that it switched from unmanaged to managed
+    /// status, so the manager needs to rediscover its location.
+    remanage: Rc<Notify>,
 }
 
 impl ResourceTaskCancel {
@@ -499,6 +508,7 @@ impl ResourceTaskCancel {
             id,
             lost_connection: Rc::new(Notify::new()),
             switch_host: Rc::new(Notify::new()),
+            remanage: Rc::new(Notify::new()),
         }
     }
 }

--- a/src/host/non_ha.rs
+++ b/src/host/non_ha.rs
@@ -144,9 +144,10 @@ impl Host {
                 HostMessage::Resource(message) => {
                     panic!("Unexpected to receive message '{message:?}' in non-HA mode.")
                 }
-                HostMessage::Command(command) => {
-                    warn!("Unexpected to receive command '{command:?}' in non-HA mode.")
-                }
+                HostMessage::Command(command) => match command {
+                    HostCommand::Remanage(_) => {}
+                    other => warn!("Unexpected to receive command '{other:?}' in non-HA mode."),
+                },
                 HostMessage::TaskDone(id) => {
                     panic!("Unexpected to receive message 'None({id})' in non-HA mode.")
                 }
@@ -195,9 +196,10 @@ impl Host {
         while let Some(event) = tasks.next().await {
             debug!("Host {} got event: {event:?}", self.id());
             match event {
-                HostMessage::Command(command) => {
-                    panic!("Unexpected to receive command '{command:?}' in non-HA mode.")
-                }
+                HostMessage::Command(command) => match command {
+                    HostCommand::Remanage(_) => {}
+                    other => warn!("Unexpected to receive command '{other:?}' in non-HA mode."),
+                },
                 HostMessage::Resource(event) => {
                     let id = &event.resource_group.id;
                     match event.kind {

--- a/src/manager/http.rs
+++ b/src/manager/http.rs
@@ -332,7 +332,7 @@ async fn set_managed(
                 rg.id(),
                 if payload.managed { "true" } else { "false" }
             );
-            rg.set_managed(payload.managed);
+            rg.update_managed(payload.managed).await;
             let event = if payload.managed {
                 Event::Manage
             } else {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -209,14 +209,29 @@ impl ResourceGroup {
         *managed_status
     }
 
-    /// Sets resources group's managed status
-    pub fn set_managed(&self, managed: bool) {
+
+    /// Set the managed status for the first time when the manager is starting up.
+    pub fn set_initial_managed(&self, managed: bool) {
         let mut managed_status = self.managed.lock().unwrap();
+
+        *managed_status = managed;
+    }
+
+    /// Update resources group's managed status during runtime.
+    pub fn update_managed(&self, managed: bool) {
+        let remanaged = {
+            let mut managed_status = self.managed.lock().unwrap();
+            let was_managed = *managed_status;
+
+            *managed_status = managed;
+
+            !was_managed && managed
+        };
 
         // When a resource transitions from being unmanaged to being managed, any assumptions about
         // its state MUST be revalidated before the manager can take any actions on it. Therefore,
         // clear any out of date knowledge on whether it was known to be running somewhere.
-        if !*managed_status && managed {
+        if remanaged {
             for host in self.hosts() {
                 self.root.set_status_recursive(
                     ResourceStatus::Unknown(
@@ -228,8 +243,6 @@ impl ResourceGroup {
 
             self.root.clear_resource_group_knowledge(&self.id());
         }
-
-        *managed_status = managed;
     }
 
     pub fn is_running_nowhere(&self) -> bool {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -115,6 +115,11 @@ impl ResourceGroup {
         self.failover_node.as_ref()
     }
 
+    /// Get an iterator over the hosts of this ResourceGroup.
+    fn hosts(&self) -> impl Iterator<Item = &Arc<Host>> {
+        std::iter::once(&self.home_node).chain(self.failover_node.iter())
+    }
+
     /// When beginning to manage a resource group on a given Host, add the Host ID to each
     /// resource's list of Hosts that the resource should be running on.
     fn apply_group_to_host(&self, host: &HostId) {
@@ -212,16 +217,12 @@ impl ResourceGroup {
         // its state MUST be revalidated before the manager can take any actions on it. Therefore,
         // clear any out of date knowledge on whether it was known to be running somewhere.
         if !*managed_status && managed {
-            self.root.set_status_recursive(
-                ResourceStatus::Unknown("Manager is beginning management of resource.".to_string()),
-                &self.home_node.id(),
-            );
-            if let Some(failover_node) = &self.failover_node {
+            for host in self.hosts() {
                 self.root.set_status_recursive(
                     ResourceStatus::Unknown(
                         "Manager is beginning management of resource.".to_string(),
                     ),
-                    &failover_node.id(),
+                    &host.id(),
                 );
             }
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -2,7 +2,7 @@
 // Copyright 2025. Triad National Security, LLC.
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     sync::{Arc, Mutex},
 };
 
@@ -115,6 +115,18 @@ impl ResourceGroup {
         self.failover_node.as_ref()
     }
 
+    /// When beginning to manage a resource group on a given Host, add the Host ID to each
+    /// resource's list of Hosts that the resource should be running on.
+    fn apply_group_to_host(&self, host: &HostId) {
+        self.root.apply_group_to_host(host, &self.id());
+    }
+
+    /// When ceasing management of a resource group on a given Host, remove the Host ID from each
+    /// resource's list of Hosts that the resource should be running on.
+    pub fn remove_group_from_host(&self, host: &HostId) {
+        self.root.remove_group_from_host(host, &self.id());
+    }
+
     /// The host-driven resource management loop manages resources on a given location until
     /// either:
     ///
@@ -125,6 +137,8 @@ impl ResourceGroup {
     ///     returns back to the host management code so that the host can begin checing the
     ///     failover partner to see if the resource was started there (manual failover).
     pub async fn manage_loop(&self, client: &Client, loc: Location) -> Result<(), ManagementError> {
+        self.apply_group_to_host(&client.name);
+
         loop {
             self.update_resources(client).await?;
             match self.get_overall_status_on_host(&client.name) {
@@ -132,6 +146,7 @@ impl ResourceGroup {
                     if self.get_managed() {
                         self.start_resources(client, loc).await?;
                     } else if !self.root.is_running() {
+                        self.remove_group_from_host(&client.name);
                         return Ok(());
                     }
                 }
@@ -163,9 +178,14 @@ impl ResourceGroup {
 
     /// Attempt to stop the resources in this resource group.
     pub async fn stop_resources(&self, client: &Client) -> Result<(), ManagementError> {
+        self.remove_group_from_host(&client.name);
+
         self.root.stop_recursive(client).await
     }
 
+    // TODO: this could have a clearer name. Maybe break it up into multiple methods:
+    //   - any_resource_in_group_stopped() -> bool
+    //   - all_resources_in_group_started() -> bool
     pub fn get_overall_status_on_host(&self, host: &HostId) -> ResourceStatus {
         let statuses = self.resources().map(|r| r.status_on_host(host));
 
@@ -204,6 +224,8 @@ impl ResourceGroup {
                     &failover_node.id(),
                 );
             }
+
+            self.root.clear_resource_group_knowledge(&self.id());
         }
 
         *managed_status = managed;
@@ -259,6 +281,8 @@ impl ResourceGroup {
 
         get_worst_error(future::join_all(futures).await.into_iter()).inspect_err(|e| {
             if matches!(e, ManagementError::Connection) {
+                self.remove_group_from_host(&client.name);
+
                 self.root.set_status_recursive(
                     ResourceStatus::Unknown("Connection to remote host lost.".to_string()),
                     &client.name,
@@ -328,7 +352,13 @@ pub type HostStatusMap = HashMap<HostId, ResourceStatus>;
 
 #[derive(Clone, Debug, Default)]
 struct PerHostStatus {
+    /// The resource's status on this Host.
     status: ResourceStatus,
+
+    /// The set of parents of this Resource which are running on this Host. This determines whether
+    /// the resource is supposed to be started / stopped on this Host. When the set is empty, the
+    /// resource should be stopped. When the set is nonempty, the resource should be started.
+    started_groups: HashSet<ResourceId>,
 }
 
 /// A Resource's state is represented by a map from Hosts to Statuses.
@@ -389,6 +419,29 @@ impl ResourceState {
         ent.status = new_status;
         old_status.status
     }
+
+    /// How many times this resource is supposed to be started across a single host. If the result
+    /// is > 1, it means that multiple parents of this resource are both supposed to be running on
+    /// this host.
+    fn started_count_on_host(&self, host: &HostId) -> usize {
+        self.inner
+            .lock()
+            .unwrap()
+            .get(host)
+            .expect("Host {host} must have an entry in the status map")
+            .started_groups
+            .len()
+    }
+
+    /// How many times this resource is supposed to be started across the entire cluster.
+    fn started_count(&self) -> usize {
+        self.inner
+            .lock()
+            .unwrap()
+            .values()
+            .map(|h| h.started_groups.len())
+            .sum()
+    }
 }
 
 impl Resource {
@@ -417,6 +470,52 @@ impl Resource {
             state: state.clone(),
             id: ResourceId(res.name.clone()),
             args,
+        }
+    }
+
+    fn apply_group_to_host(&self, host: &HostId, root: &ResourceId) {
+        {
+            let mut map = self.state.inner.lock().unwrap();
+            let ent = map
+                .get_mut(host)
+                .expect("Host {host} must have an entry in the status map");
+            ent.started_groups.insert(root.clone());
+        }
+
+        let started_count = self.state.started_count();
+
+        if started_count > self.count {
+            panic!(
+                "Resource {} is managed too many times: {}, maximum allowed: {}",
+                self.id, started_count, self.count
+            );
+        }
+
+        for child in &self.dependents {
+            child.apply_group_to_host(host, root);
+        }
+    }
+
+    fn remove_group_from_host(&self, host: &HostId, root: &ResourceId) {
+        let mut map = self.state.inner.lock().unwrap();
+        let ent = map
+            .get_mut(host)
+            .expect("Host {host} must have an entry in the status map");
+
+        ent.started_groups.remove(root);
+
+        for child in &self.dependents {
+            child.remove_group_from_host(host, root);
+        }
+    }
+
+    fn clear_resource_group_knowledge(&self, resource_group: &ResourceId) {
+        for per_host_map in self.state.inner.lock().unwrap().values_mut() {
+            per_host_map.started_groups.remove(resource_group);
+        }
+
+        for child in &self.dependents {
+            child.clear_resource_group_knowledge(resource_group);
         }
     }
 
@@ -508,6 +607,12 @@ impl Resource {
         let results = self.dependents.iter().map(|r| r.stop_recursive(client));
 
         get_worst_error(future::join_all(results).await.into_iter())?;
+
+        if self.state.started_count_on_host(&client.name) > 0 {
+            // If this resource still has a started parent on this host, then it shouldn't be
+            // stopped.
+            return Ok(());
+        }
 
         match self.stop(client).await {
             Ok(AgentReply::Success(ocf::Status::Success)) => {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -209,7 +209,6 @@ impl ResourceGroup {
         *managed_status
     }
 
-
     /// Set the managed status for the first time when the manager is starting up.
     pub fn set_initial_managed(&self, managed: bool) {
         let mut managed_status = self.managed.lock().unwrap();
@@ -218,7 +217,7 @@ impl ResourceGroup {
     }
 
     /// Update resources group's managed status during runtime.
-    pub fn update_managed(&self, managed: bool) {
+    pub async fn update_managed(&self, managed: bool) {
         let remanaged = {
             let mut managed_status = self.managed.lock().unwrap();
             let was_managed = *managed_status;
@@ -232,6 +231,8 @@ impl ResourceGroup {
         // its state MUST be revalidated before the manager can take any actions on it. Therefore,
         // clear any out of date knowledge on whether it was known to be running somewhere.
         if remanaged {
+            self.root.clear_resource_group_knowledge(&self.id());
+
             for host in self.hosts() {
                 self.root.set_status_recursive(
                     ResourceStatus::Unknown(
@@ -239,9 +240,10 @@ impl ResourceGroup {
                     ),
                     &host.id(),
                 );
-            }
 
-            self.root.clear_resource_group_knowledge(&self.id());
+                host.command(HostCommand::Remanage(self.id().to_string()))
+                    .await;
+            }
         }
     }
 

--- a/src/test_env/ha.rs
+++ b/src/test_env/ha.rs
@@ -24,7 +24,20 @@ impl HaEnvironment {
     pub fn new_ha(test_id: String, agent_binary_path: &str, manager_binary_path: &str) -> Self {
         let ports = get_ports();
         let env = TestEnvironment::new("ha", &test_id, agent_binary_path, manager_binary_path);
-        let config = ha_config(ports, test_id.clone());
+        let config = ha_config(ports, &test_id);
+        env.write_out_config(&config);
+        Self {
+            env,
+            test_id,
+            ports,
+            config,
+        }
+    }
+
+    pub fn new_shared(test_id: String, agent_binary_path: &str, manager_binary_path: &str) -> Self {
+        let ports = get_ports();
+        let env = TestEnvironment::new("shared", &test_id, agent_binary_path, manager_binary_path);
+        let config = shared_config(ports, &test_id);
         env.write_out_config(&config);
         Self {
             env,
@@ -146,7 +159,7 @@ impl HaEnvironment {
         .unwrap();
     }
 
-    fn get_status(&self) -> http::ClusterJson {
+    pub fn get_status(&self) -> http::ClusterJson {
         let status = commands::status::get_status(Some(&self.socket_path())).unwrap();
         eprintln!("{status:#?}");
         status
@@ -334,6 +347,16 @@ impl Drop for HaEnvironment {
     /// is, started on both hosts in a pair.
     fn drop(&mut self) {
         for resource in self.config.resources.iter() {
+            // The following resource types are not exclusive and are allowed to be double-started.
+            // XXX: Come up with a more robust way to detect this in arbitrary configs rather than
+            // just hard-coding this list?
+            if matches!(
+                resource.kind.as_str(),
+                "heartbeat/route" | "heartbeat/filesystem" | "heartbeat/export"
+            ) {
+                continue;
+            }
+
             if self.env.resource_is_started(resource, 0)
                 && self.env.resource_is_started(resource, 1)
             {
@@ -344,7 +367,7 @@ impl Drop for HaEnvironment {
 }
 
 /// Creates an HA-pair config for use in the ha tests.
-fn ha_config(ports: [u16; 2], test_id: String) -> Config {
+fn ha_config(ports: [u16; 2], test_id: &str) -> Config {
     let mut config = Config {
         hosts: Vec::new(),
         resources: Vec::new(),
@@ -394,6 +417,44 @@ fn ha_config(ports: [u16; 2], test_id: String) -> Config {
         config.hosts.push(host);
         config.resources.push(root_resource);
         config.resources.push(child_resource);
+        config.resource_groups.push(resource_group);
+    }
+
+    config
+}
+
+fn shared_config(ports: [u16; 2], test_id: &str) -> Config {
+    let path = test_path("configs/nfs.yaml");
+    let config = std::fs::read_to_string(path).unwrap();
+
+    // Use the existing NFS example config...
+    let mut config: Config = serde_yaml::from_str(&config).unwrap();
+    // ...but the hosts and resource groups need to be fixed up to reference the specific test
+    // ports. so strip them out, just keeping the resources.
+    std::mem::take(&mut config.hosts);
+    std::mem::take(&mut config.resource_groups);
+
+    for (i, port) in ports.iter().enumerate() {
+        let my_hostname = || -> String { format!("127.0.0.1:{}", port) };
+        let partner_hostname =
+            || -> String { format!("127.0.0.1:{}", if i == 0 { ports[1] } else { ports[0] }) };
+
+        let host = config::Host {
+            hostname: my_hostname(),
+            fence_agent: Some("fence_test".to_string()),
+            fence_parameters: Some(HashMap::from([
+                ("target".to_string(), format!("{test_id}_{i}")),
+                ("test_id".to_string(), format!("shared/{test_id}")),
+            ])),
+        };
+
+        let resource_group = config::ResourceGroup {
+            home_host: my_hostname(),
+            failover_hosts: vec![partner_hostname()],
+            root: format!("ip_addr_{i}"),
+        };
+
+        config.hosts.push(host);
         config.resource_groups.push(resource_group);
     }
 

--- a/src/test_env/mod.rs
+++ b/src/test_env/mod.rs
@@ -313,17 +313,25 @@ impl TestEnvironment {
     /// Get the path to the "resource state file" used in a test -- that is, the file whose
     /// presence indicates the resource is running and whose absence indicates it is stopped.
     fn get_resource_path(&self, resource: &config::Resource, agent: usize) -> String {
+        let fix_path = |path: &String| path.replace("/", "_");
+
         let path = match resource.kind.as_str() {
-            "heartbeat/ZFS" => &format!("zfs.{}", resource.parameters.get("pool").unwrap()),
-            "lustre/Lustre" => &format!(
+            "heartbeat/ZFS" => format!("zfs.{}", resource.parameters.get("pool").unwrap()),
+            "lustre/Lustre" => format!(
                 "lustre.{}",
-                resource
-                    .parameters
-                    .get("mountpoint")
-                    .unwrap()
-                    .replace("/", "_")
+                fix_path(resource.parameters.get("mountpoint").unwrap())
             ),
-            _ => unreachable!(),
+            "heartbeat/ip" => format!("ip.{}", resource.parameters.get("ip").unwrap()),
+            "heartbeat/route" => format!("route.{}", resource.parameters.get("route").unwrap()),
+            "heartbeat/filesystem" => format!(
+                "fs.{}",
+                fix_path(resource.parameters.get("directory").unwrap())
+            ),
+            "heartbeat/export" => format!(
+                "export.{}",
+                fix_path(resource.parameters.get("directory").unwrap())
+            ),
+            _ => todo!("Need to add resource kind '{}' to list.", resource.kind),
         };
         let path = format!("{}_{agent}.{}", self.test_id, path);
         self.private_dir_path.clone() + "/" + &path

--- a/tests/shared.rs
+++ b/tests/shared.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026. Triad National Security, LLC.
+
+#[cfg(test)]
+mod tests {
+    use halo_lib::test_env::ha::*;
+
+    /// Create a TestEnvironment for a test.
+    ///
+    /// The path to the remote binary needs to be determined here and passed into the
+    /// TestEnvironment constructor because the environment variable is only defined when compiling
+    /// tests.
+    fn test_env_helper(test_id: &str) -> HaEnvironment {
+        HaEnvironment::new_shared(
+            test_id.to_string(),
+            env!("CARGO_BIN_EXE_halo_remote"),
+            env!("CARGO_BIN_EXE_halo_manager"),
+        )
+    }
+
+    /// Startup, both agents running, all resources stopped.
+    /// Agents should start resources on their home nodes.
+    #[test]
+    fn startup1() {
+        let env = test_env_helper("startup1");
+        let _a = env.start_agent(0);
+        let _b = env.start_agent(1);
+        let _m = env.start_manager(true);
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        let status = env.get_status();
+        for resource in status.resources {
+            let (st, _) = resource.single_host_status();
+            match resource.kind.as_str() {
+                "heartbeat/ip" => assert_eq!(st, "Running"),
+                _ => {
+                    for st in resource.status.values() {
+                        assert_eq!(st.status, "Running");
+                    }
+                }
+            }
+        }
+    }
+
+    /// All resources running on one host, after failback, exclusive resources should be running on
+    /// their home host and shared resources should be running everywhere.
+    #[test]
+    fn failback1() {
+        let env = test_env_helper("failback1");
+
+        env.start_resource("ip_addr_0", 0);
+        env.start_resource("ip_addr_1", 0);
+
+        let _a = env.start_agent(0);
+        let _b = env.start_agent(1);
+        let _m = env.start_manager(true);
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        let status = env.get_status();
+        for resource in status.resources {
+            let st0 = resource.status.get(&env.agent_id(0)).unwrap();
+            assert_eq!(st0.status, "Running");
+
+            let st1 = &resource.status.get(&env.agent_id(1)).unwrap().status;
+            assert!((st1 == "Stopped") | (st1 == "Unknown"));
+        }
+
+        env.failback(1).unwrap();
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        let status = env.get_status();
+        for resource in status.resources {
+            let (st, _) = resource.single_host_status();
+            match resource.kind.as_str() {
+                "heartbeat/ip" => assert_eq!(st, "Running"),
+                _ => {
+                    for st in resource.status.values() {
+                        assert_eq!(st.status, "Running");
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds support for https://github.com/lanl/halo/issues/92

This adds support for more generic resources in two ways:

- relaxing the constraint that resources must only run on a single host at a time (mutual exclusion requirement). Some resources can safely run on multiple hosts simultaneously.
- relaxing the constraint that resource groups can only run on at most 2 hosts. This PR doesn't add full support for larger failover groups, but it updates the data structures to be able to support those more easily in the future.

The above requirements mean a new config file format is needed because the existing format is too rigid and doesn't easily allow for those cases to be expressed.