### PR TITLE
Update resource status representation

### DIFF
--- a/docs/admin_guide.typ
+++ b/docs/admin_guide.typ
@@ -80,6 +80,13 @@ systemctl restart halo.service
 on the management server is *always* safe
 and never interferes with the availability of the managed filesystem.
 
+== Backwards and Forwards Compatibility Policy
+
+HALO does not support mixed-vesion deployments. The CLI utility, management service,
+and remote service must all come from the same version.
+The RPC and HTTP interfaces that these components communicate over are allowed
+to change in incompatible ways, such that a mixed-version deployment can break.
+
 = Configuration File
 
 The HALO management daemon expects a configuration file in YAML format.

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -307,9 +307,11 @@ impl Cluster {
                         )
                     })
                     .collect();
-                Resource::from_config(
-                    self.me, dependents, /*host, failover_host,*/ self.id, args,
-                )
+                let mut host_list = vec![host.id().clone()];
+                if let Some(failover_host) = failover_host {
+                    host_list.push(failover_host.id().clone());
+                };
+                Resource::from_config(self.me, dependents, self.id, args, host_list)
             }
         }
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -20,14 +20,17 @@ pub fn status(cli: &Cli, args: &StatusArgs) -> HandledResult<()> {
     let cluster = get_status(cli.socket.as_deref())?;
 
     for res in cluster.resources {
-        if args.exclude_normal && res.status == "Running" {
+        if args.exclude_normal && res.single_host_status().0 == "Running" {
             continue;
         }
 
         print!("{:<20}\t", res.id);
         print!("({})\t", res.kind);
-        print!("{}", res.status);
-        match res.status.as_str() {
+
+        let (status, maybe_comment) = res.single_host_status();
+
+        print!("{}", status);
+        match status {
             "Running" => print!(" on {}", res.home_host),
             "Running (Failed Over)" => print!(
                 " on {}",
@@ -52,7 +55,7 @@ pub fn status(cli: &Cli, args: &StatusArgs) -> HandledResult<()> {
             print!("]");
         }
 
-        if let Some(comment) = res.comment {
+        if let Some(comment) = maybe_comment {
             print!(" {comment} ");
         }
 

--- a/src/host/ha.rs
+++ b/src/host/ha.rs
@@ -285,9 +285,10 @@ impl Host {
 
                         continue;
                     }
-                    rg.root.set_status_recursive(ResourceStatus::Unknown(
-                        "Connection to remote host lost.".to_string(),
-                    ));
+                    rg.root.set_status_recursive(
+                        ResourceStatus::Unknown("Connection to remote host lost.".to_string()),
+                        &self.id(),
+                    );
 
                     // If the resource group is unmanaged, the admin might start it on the partner,
                     // so just check on it over there.
@@ -404,9 +405,12 @@ impl Host {
                         // cancel management.
                         Message::TaskCanceled => {
                             let rg = cluster.get_resource_group(id);
-                            rg.root.set_status_recursive(ResourceStatus::Unknown(
-                                "Connection to remote host lost.".to_string(),
-                            ));
+                            rg.root.set_status_recursive(
+                                ResourceStatus::Unknown(
+                                    "Connection to remote host lost.".to_string(),
+                                ),
+                                &self.id(),
+                            );
                             state.prep_for_failover(t);
                         }
                         Message::ResourceError => {
@@ -617,9 +621,13 @@ impl Host {
 
             for token in tokens_to_send {
                 let rg = cluster.get_resource_group(&token.id);
-                rg.root.set_status_recursive(ResourceStatus::Error(
-                    "Fencing this reource's host failed. Management cannot proceed.".to_string(),
-                ));
+                rg.root.set_status_recursive(
+                    ResourceStatus::Error(
+                        "Fencing this reource's host failed. Management cannot proceed."
+                            .to_string(),
+                    ),
+                    &self.id(),
+                );
                 state.resources_with_errors.push(token);
             }
 
@@ -654,7 +662,8 @@ impl Host {
         for token in tokens_to_send {
             let rg = cluster.get_resource_group(&token.id);
             // We know resource is stopped if fencing succeeded:
-            rg.root.set_status_recursive(ResourceStatus::Stopped);
+            rg.root
+                .set_status_recursive(ResourceStatus::Stopped, &self.id());
 
             self.send_message_to_partner(token, Message::ManageResourceGroup)
                 .await;
@@ -663,11 +672,11 @@ impl Host {
 
     fn update_resource_groups_stopped(&self, cluster: &Cluster) {
         for rg in cluster.host_home_resource_groups(self) {
-            rg.has_been_stopped(Location::Home);
+            rg.has_been_stopped(&self.id());
         }
 
         for rg in cluster.host_home_resource_groups(self.ha_failover_partner()) {
-            rg.has_been_stopped(Location::Away);
+            rg.has_been_stopped(&self.id());
         }
     }
 
@@ -775,15 +784,7 @@ impl Host {
     ) -> (WhereTo, Message) {
         let rg = cluster.get_resource_group(&token.id);
 
-        // If the resource is known to be stopped at the partner, then we can confidently update
-        // the overall status to stopped if it's stopped here as well. But if the resource state is
-        // unknown on the partner, the overall resource state must remain unknown.
-        let update_status_if_stopped = rg.is_stopped_at_location(token.location.swap());
-
-        match rg
-            .is_running_here(client, token.location, update_status_if_stopped)
-            .await
-        {
+        match rg.update_resources(client).await {
             Ok(is_running_here) => {
                 if is_running_here {
                     (WhereTo::Here, Message::ManageResourceGroup)

--- a/src/host/non_ha.rs
+++ b/src/host/non_ha.rs
@@ -62,7 +62,12 @@ impl Host {
         loop {
             let resource_groups_to_observe: Vec<_> = cluster
                 .host_home_resource_groups(self)
-                .filter(|rg| !matches!(rg.get_overall_status(), ResourceStatus::Error(_)))
+                .filter(|rg| {
+                    !matches!(
+                        rg.get_overall_status_on_host(&self.id()),
+                        ResourceStatus::Error(_)
+                    )
+                })
                 .collect();
 
             if resource_groups_to_observe.is_empty() {
@@ -208,9 +213,12 @@ impl Host {
                         Message::RequestFailover => {
                             state.resource_task_exited(id);
                             let rg = cluster.get_resource_group(id);
-                            rg.root.set_status_recursive(ResourceStatus::Unknown(
-                                "Connection to remote host lost.".to_string(),
-                            ));
+                            rg.root.set_status_recursive(
+                                ResourceStatus::Unknown(
+                                    "Connection to remote host lost.".to_string(),
+                                ),
+                                &self.id(),
+                            );
                             if self.ready_for_reboot(state, event.resource_group) {
                                 return;
                             }
@@ -249,7 +257,7 @@ impl Host {
     ) {
         let rg = cluster.get_resource_group(&rg_name);
         match rg
-            .observe_loop(client, Location::Home)
+            .observe_loop(client)
             .await
             .expect_err("observe_loop() should not exit until an error occurs in this usage.")
         {

--- a/src/manager/http.rs
+++ b/src/manager/http.rs
@@ -16,7 +16,7 @@ use {
 
 use crate::{
     cluster::Cluster,
-    host::{FenceResult, Host, HostCommand},
+    host::{FenceResult, Host, HostCommand, HostId},
     resource::{Resource, ResourceStatus},
     state::{Event, Record},
 };
@@ -98,35 +98,59 @@ impl ResourceJson {
     fn build(
         res: &Resource,
         managed: bool,
-        home_host: String,
-        failover_host: Option<String>,
+        home_host: &HostId,
+        failover_host: &Option<HostId>,
     ) -> Self {
         let mut comment = None;
+        let status: &str;
 
-        let status = match res.status() {
-            ResourceStatus::Unknown(ref reason) => {
-                comment = Some(reason.clone());
-                "Unknown"
+        let status_map = res.status();
+
+        'status: {
+            if *status_map.get(home_host).unwrap() == ResourceStatus::Running {
+                status = "Running";
+                break 'status;
+            };
+
+            if let Some(failover_host) = &failover_host {
+                if *status_map.get(failover_host).unwrap() == ResourceStatus::Running {
+                    status = "Running (Failed Over)";
+                    break 'status;
+                }
             }
-            ResourceStatus::Error(ref reason) => {
-                comment = Some(reason.clone());
-                "Error"
+
+            for st in status_map.values() {
+                if let ResourceStatus::Error(reason) = st {
+                    comment = Some(reason.clone());
+                    status = "Error";
+                    break 'status;
+                }
             }
-            ResourceStatus::Stopped => "Stopped",
-            ResourceStatus::RunningOnAway => "Running (Failed Over)",
-            ResourceStatus::RunningOnHome => "Running",
+
+            for st in status_map.values() {
+                if let ResourceStatus::Unknown(reason) = st {
+                    comment = Some(reason.clone());
+                    status = "Unknown";
+                    break 'status;
+                }
+            }
+
+            if status_map.values().all(|st| *st == ResourceStatus::Stopped) {
+                status = "Stopped";
+            } else {
+                status = "Unexpected (BUG)";
+            }
         }
-        .to_string();
 
         Self {
             id: res.id.to_string(),
             kind: res.kind.clone(),
             parameters: res.parameters.clone(),
-            status,
+            status: status.to_string(),
             comment,
             managed,
-            home_host,
-            failover_host,
+            home_host: home_host.to_string(),
+            failover_host: failover_host.as_ref().map(|h| h.to_string()),
         }
     }
 }
@@ -191,14 +215,8 @@ async fn get_status(cluster: Arc<Cluster>) -> Json<ClusterJson> {
                 let managed = rg.get_managed();
                 let home_host = rg.home_node().id();
                 let failover_host = rg.failover_node().map(|h| h.id());
-                rg.resources().map(move |res| {
-                    ResourceJson::build(
-                        res,
-                        managed,
-                        home_host.to_string(),
-                        failover_host.as_ref().map(|h| h.to_string()),
-                    )
-                })
+                rg.resources()
+                    .map(move |res| ResourceJson::build(res, managed, &home_host, &failover_host))
             })
             .collect(),
 

--- a/src/manager/http.rs
+++ b/src/manager/http.rs
@@ -87,11 +87,76 @@ pub struct ResourceJson {
     pub id: String,
     pub kind: String,
     pub parameters: HashMap<String, String>,
-    pub status: String,
-    pub comment: Option<String>,
+    pub status: HashMap<String, StatusJson>,
     pub managed: bool,
     pub home_host: String,
     pub failover_host: Option<String>,
+}
+
+enum StatusWhere {
+    Nowhere,
+    Home(Option<String>),
+    Failover(Option<String>),
+}
+
+impl ResourceJson {
+    fn is_stopped_everywhere(&self) -> bool {
+        self.status.values().all(|st| st.status == "Stopped")
+    }
+
+    fn has_status(&self, requested: &str) -> StatusWhere {
+        let st = self.status.get(&self.home_host).unwrap();
+        if st.status == requested {
+            return StatusWhere::Home(st.comment.clone());
+        }
+
+        if let Some(failover_host) = &self.failover_host {
+            let st = self.status.get(failover_host).unwrap();
+            if st.status == requested {
+                return StatusWhere::Failover(st.comment.clone());
+            }
+        }
+
+        StatusWhere::Nowhere
+    }
+
+    /// Returns a single status value together with an optional comment.
+    pub fn single_host_status(&self) -> (&'static str, Option<String>) {
+        match self.has_status("Running") {
+            StatusWhere::Home(_) => return ("Running", None),
+            StatusWhere::Failover(_) => return ("Running (Failed Over)", None),
+            _ => {}
+        };
+
+        if self.is_stopped_everywhere() {
+            return ("Stopped", None);
+        }
+
+        for status in ["Error", "Unknown"] {
+            match self.has_status(status) {
+                StatusWhere::Home(comment) => return (status, comment),
+                StatusWhere::Failover(comment) => return (status, comment),
+                _ => {}
+            }
+        }
+
+        ("Unexpected", None)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct StatusJson {
+    pub status: String,
+    pub comment: Option<String>,
+}
+
+impl StatusJson {
+    fn build(status: &str, reason: Option<&str>) -> Self {
+        Self {
+            status: status.to_owned(),
+            comment: reason.map(|c| c.to_owned()),
+        }
+    }
 }
 
 impl ResourceJson {
@@ -101,53 +166,29 @@ impl ResourceJson {
         home_host: &HostId,
         failover_host: &Option<HostId>,
     ) -> Self {
-        let mut comment = None;
-        let status: &str;
-
-        let status_map = res.status();
-
-        'status: {
-            if *status_map.get(home_host).unwrap() == ResourceStatus::Running {
-                status = "Running";
-                break 'status;
-            };
-
-            if let Some(failover_host) = &failover_host {
-                if *status_map.get(failover_host).unwrap() == ResourceStatus::Running {
-                    status = "Running (Failed Over)";
-                    break 'status;
-                }
-            }
-
-            for st in status_map.values() {
-                if let ResourceStatus::Error(reason) = st {
-                    comment = Some(reason.clone());
-                    status = "Error";
-                    break 'status;
-                }
-            }
-
-            for st in status_map.values() {
-                if let ResourceStatus::Unknown(reason) = st {
-                    comment = Some(reason.clone());
-                    status = "Unknown";
-                    break 'status;
-                }
-            }
-
-            if status_map.values().all(|st| *st == ResourceStatus::Stopped) {
-                status = "Stopped";
-            } else {
-                status = "Unexpected (BUG)";
-            }
-        }
+        let status = res
+            .status()
+            .iter()
+            .map(|(host, status)| {
+                (
+                    host.to_string(),
+                    match status {
+                        ResourceStatus::Running => StatusJson::build("Running", None),
+                        ResourceStatus::Stopped => StatusJson::build("Stopped", None),
+                        ResourceStatus::Unknown(reason) => {
+                            StatusJson::build("Unknown", Some(reason))
+                        }
+                        ResourceStatus::Error(reason) => StatusJson::build("Error", Some(reason)),
+                    },
+                )
+            })
+            .collect();
 
         Self {
             id: res.id.to_string(),
             kind: res.kind.clone(),
             parameters: res.parameters.clone(),
-            status: status.to_string(),
-            comment,
+            status,
             managed,
             home_host: home_host.to_string(),
             failover_host: failover_host.as_ref().map(|h| h.to_string()),

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -157,8 +157,8 @@ impl ResourceGroup {
     ///     failover partner to see if the resource was started there (manual failover).
     pub async fn manage_loop(&self, client: &Client, loc: Location) -> Result<(), ManagementError> {
         loop {
-            self.update_resources(client, loc).await?;
-            match self.get_overall_status() {
+            self.update_resources(client).await?;
+            match self.get_overall_status_on_host(&client.name) {
                 ResourceStatus::Stopped => {
                     if self.get_managed() {
                         self.start_resources(client, loc).await?;
@@ -166,7 +166,7 @@ impl ResourceGroup {
                         return Ok(());
                     }
                 }
-                ResourceStatus::RunningOnHome | ResourceStatus::RunningOnAway => {}
+                ResourceStatus::Running => {}
                 other => {
                     warn!("resource status was unexpected: {other:?}");
                     return Err(ManagementError::Configuration);
@@ -179,38 +179,12 @@ impl ResourceGroup {
     /// Observe some resources.
     ///
     /// Exits only when an error occurs.
-    pub async fn observe_loop(
-        &self,
-        client: &Client,
-        loc: Location,
-    ) -> Result<(), ManagementError> {
+    pub async fn observe_loop(&self, client: &Client) -> Result<(), ManagementError> {
         loop {
-            self.update_resources(client, loc).await?;
+            self.update_resources(client).await?;
 
             tokio::time::sleep(tokio::time::Duration::from_millis(self.args.sleep_time)).await;
         }
-    }
-
-    /// Check the statuses of each of the resources in this resource group.
-    ///
-    /// This function updates the status of each resource (zpool and target) in the resource
-    /// group, and the host.
-    ///
-    /// When checking a resource's status, errors can occur at multiple levels:
-    ///
-    /// - Errors in communicating with the remote agent--for example, "Connection timed out"--lead
-    ///   to this function returning an Err() variant containing the error. Nothing can be
-    ///   concluded about the status of a remote resource in such a case, so the status is set to
-    ///   Unknown.
-    /// - When communication with the remote agent succesfully occurred, but the remote agent
-    ///   returned an error status, this function returns an Ok() variant and sets the resource
-    ///   status to the appropriate value to indicate the kind of error returned.
-    async fn update_resources(
-        &self,
-        client: &Client,
-        loc: Location,
-    ) -> Result<(), ManagementError> {
-        self.is_running_here(client, loc, true).await.map(|_| ())
     }
 
     /// Attempt to start the resources in this resource group on the given location.
@@ -218,8 +192,8 @@ impl ResourceGroup {
         let res = self.root.start_if_needed_recursive(client, loc).await;
 
         match res {
-            Ok(()) => self.set_host_state(State::Running, loc),
-            Err(ManagementError::Connection) => self.set_host_state(State::Unknown, loc),
+            Ok(()) => self.set_host_state(State::Running, &client.name),
+            Err(ManagementError::Connection) => self.set_host_state(State::Unknown, &client.name),
             _ => {}
         };
 
@@ -228,24 +202,19 @@ impl ResourceGroup {
 
     /// Attempt to stop the resources in this resource group.
     pub async fn stop_resources(&self, client: &Client) -> Result<(), ManagementError> {
-        let loc = match self.root.status() {
-            ResourceStatus::RunningOnHome => Some(Location::Home),
-            ResourceStatus::RunningOnAway => Some(Location::Away),
-            _ => None,
-        };
         let res = self.root.stop_recursive(client).await;
-        if let Some(loc) = loc {
-            match res {
-                Ok(()) => self.set_host_state(State::Stopped, loc),
-                Err(ManagementError::Connection) => self.set_host_state(State::Unknown, loc),
-                _ => {}
-            }
+
+        match res {
+            Ok(()) => self.set_host_state(State::Stopped, &client.name),
+            Err(ManagementError::Connection) => self.set_host_state(State::Unknown, &client.name),
+            _ => {}
         }
+
         res
     }
 
-    pub fn get_overall_status(&self) -> ResourceStatus {
-        let statuses = self.resources().map(|r| r.status());
+    pub fn get_overall_status_on_host(&self, host: &HostId) -> ResourceStatus {
+        let statuses = self.resources().map(|r| r.status_on_host(host));
 
         ResourceStatus::get_worst(statuses.into_iter())
     }
@@ -279,8 +248,8 @@ impl ResourceGroup {
         *managed_status = managed;
     }
 
-    pub fn has_been_stopped(&self, loc: Location) {
-        self.set_host_state(State::Stopped, loc);
+    pub fn has_been_stopped(&self, host: &HostId) {
+        self.set_host_state(State::Stopped, host);
     }
 
     pub fn is_running_nowhere(&self) -> bool {
@@ -297,13 +266,21 @@ impl ResourceGroup {
         state == State::Stopped
     }
 
-    fn set_host_state(&self, state: State, loc: Location) {
-        let host = match loc {
-            Location::Home => &self.home_node,
-            Location::Away => self
+    fn set_host_state(&self, state: State, host_id: &HostId) {
+        let host = if host_id == &self.home_node.host.id() {
+            &self.home_node
+        } else {
+            let failover_host = self
                 .failover_node
                 .as_ref()
-                .expect("Failover node must be set."),
+                .expect("Failover node must be set.");
+            if host_id != &failover_host.host.id() {
+                panic!(
+                    "Unexpeced host id: {host_id} for setting resource state of {}",
+                    self.id()
+                );
+            }
+            failover_host
         };
 
         host.set_state(state);
@@ -322,60 +299,57 @@ impl ResourceGroup {
         }
     }
 
-    fn assert_not_running_elsewhere(&self, loc: Location) {
-        let Some(failover_node) = &self.failover_node else {
+    fn assert_not_running_elsewhere(&self, host: &HostId) {
+        if !self.failover_node.is_some() {
             // This assertion is irrelevant for non-HA clusters, so just return.
             return;
         };
 
-        match loc {
-            Location::Home => {
-                if self.root.status() == ResourceStatus::RunningOnAway
-                    || failover_node.state() == State::Running
-                {
-                    panic!("Manager tried to manage resource {} on its home node while it still believes it to be running on its failover node.", self.id());
-                }
+        for (other_host, status) in self.root.status() {
+            if &other_host == host {
+                continue;
             }
-            Location::Away => {
-                if self.root.status() == ResourceStatus::RunningOnHome
-                    || self.home_node.state() == State::Running
-                {
-                    panic!("Manager tried to manage resource {} on its failover node while it still believes it to be running on its home node.", self.id());
-                }
+
+            if status == ResourceStatus::Running {
+                panic!("Manager tried to manage resource {} on host {} while it still believes it to be running on host {}.", self.id(), host, other_host);
             }
         }
     }
 
-    /// Check if the resource group is running on the system connected via the given Client.
+    /// Check the statuses of each of the resources in this resource group.
     ///
-    /// This checks each resource individually for the purpose of updating the status, but it uses
-    /// the result of the root resource to determine the "overall" status.
-    pub async fn is_running_here(
-        &self,
-        client: &Client,
-        loc: Location,
-        update_status_if_stopped: bool,
-    ) -> Result<bool, ManagementError> {
-        self.assert_not_running_elsewhere(loc);
+    /// This function updates the status of each resource (zpool and target) in the resource
+    /// group, and the host.
+    ///
+    /// When checking a resource's status, errors can occur at multiple levels:
+    ///
+    /// - Errors in communicating with the remote agent--for example, "Connection timed out"--lead
+    ///   to this function returning an Err() variant containing the error. Nothing can be
+    ///   concluded about the status of a remote resource in such a case, so the status is set to
+    ///   Unknown.
+    /// - When communication with the remote agent succesfully occurred, but the remote agent
+    ///   returned an error status, this function returns an Ok() variant and sets the resource
+    ///   status to the appropriate value to indicate the kind of error returned.
+    pub async fn update_resources(&self, client: &Client) -> Result<bool, ManagementError> {
+        self.assert_not_running_elsewhere(&client.name);
 
-        let futures = self
-            .resources()
-            .map(|r| r.update_status(client, loc, update_status_if_stopped));
+        let futures = self.resources().map(|r| r.update_status(client));
 
         get_worst_error(future::join_all(futures).await.into_iter()).inspect_err(|e| {
             if matches!(e, ManagementError::Connection) {
-                self.set_host_state(State::Unknown, loc);
-                self.root.set_status_recursive(ResourceStatus::Unknown(
-                    "Connection to remote host lost.".to_string(),
-                ));
+                self.set_host_state(State::Unknown, &client.name);
+                self.root.set_status_recursive(
+                    ResourceStatus::Unknown("Connection to remote host lost.".to_string()),
+                    &client.name,
+                );
             }
         })?;
 
-        if self.root.is_running() {
-            self.set_host_state(State::Running, loc);
+        if self.root.is_running_on_loc(&client.name) {
+            self.set_host_state(State::Running, &client.name);
             Ok(true)
         } else {
-            self.set_host_state(State::Stopped, loc);
+            self.set_host_state(State::Stopped, &client.name);
             Ok(false)
         }
     }
@@ -420,10 +394,67 @@ pub struct Resource {
     /// Unique identifier for the resource.
     pub id: ResourceId,
 
-    // TODO: better privacy here
-    status: Mutex<ResourceStatus>,
+    state: ResourceState,
 
     pub args: manager::Cli,
+}
+
+pub type HostStatusMap = HashMap<HostId, ResourceStatus>;
+
+#[derive(Clone, Debug, Default)]
+struct PerHostStatus {
+    status: ResourceStatus,
+}
+
+/// A Resource's state is represented by a map from Hosts to Statuses.
+///
+/// For example, a failed-over Resource might have the following status map:
+///
+///    lustre_ost00
+///     oss00   ->  Stopped
+///     oss01   ->  Running
+///
+/// A Resource whose full status is currently undiscovered might have the following map:
+///
+///     oss00   -> Unknown
+///     oss01   -> Stopped
+#[derive(Debug)]
+struct ResourceState {
+    inner: Arc<Mutex<HashMap<HostId, PerHostStatus>>>,
+}
+
+impl ResourceState {
+    fn new(host_list: Vec<HostId>) -> Self {
+        let inner = host_list
+            .into_iter()
+            .map(|h| (h, PerHostStatus::default()))
+            .collect();
+
+        Self {
+            inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+
+    fn get(&self) -> HostStatusMap {
+        self.inner
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(id, st)| (id.clone(), st.status.clone()))
+            .collect()
+    }
+
+    /// Update the status for `host` to `new_status`.
+    /// Returns the old status.
+    fn update(&self, new_status: ResourceStatus, host: &HostId) -> ResourceStatus {
+        let mut map = self.inner.lock().unwrap();
+        let ent = map
+            .get_mut(host)
+            .expect("Host {host} must have an entry in the status map");
+        let old_status = ent.clone();
+        ent.status = new_status;
+        old_status.status
+    }
 }
 
 impl Resource {
@@ -432,49 +463,41 @@ impl Resource {
         dependents: Vec<Resource>,
         id: String,
         args: manager::Cli,
+        host_list: Vec<HostId>,
     ) -> Self {
         Resource {
             kind: res.kind,
             parameters: res.parameters,
             dependents,
-            status: Mutex::new(ResourceStatus::Unknown(
-                "Manager is starting up".to_string(),
-            )),
+            state: ResourceState::new(host_list),
             id: ResourceId(id),
             args,
         }
     }
 
     /// This method checks if the resource is running on the system connected via the given Client.
-    pub async fn update_status(
-        &self,
-        client: &Client,
-        loc: Location,
-        update_status_if_stopped: bool,
-    ) -> Result<(), ManagementError> {
+    pub async fn update_status(&self, client: &Client) -> Result<(), ManagementError> {
         match self.monitor(client).await {
             Ok(AgentReply::Success(ocf::Status::Success)) => {
-                self.set_running_on_loc(loc);
+                self.set_running_on_loc(&client.name);
                 Ok(())
             }
             Ok(AgentReply::Success(ocf::Status::Error(kind, reason))) => match kind {
                 ocf::OcfError::ErrNotRunning => {
-                    if update_status_if_stopped {
-                        self.set_status(ResourceStatus::Stopped);
-                    }
+                    self.set_status(ResourceStatus::Stopped, &client.name);
                     Ok(())
                 }
                 _ => {
-                    self.set_status(ResourceStatus::Error(reason));
+                    self.set_status(ResourceStatus::Error(reason), &client.name);
                     Err(ManagementError::Configuration)
                 }
             },
             Ok(AgentReply::Error(reason)) => {
-                self.set_status(ResourceStatus::Error(reason));
+                self.set_status(ResourceStatus::Error(reason), &client.name);
                 Err(ManagementError::Configuration)
             }
             Err(e) => {
-                self.set_status(ResourceStatus::Unknown(format!("{e}")));
+                self.set_status(ResourceStatus::Unknown(format!("{e}")), &client.name);
                 Err(e.into())
             }
         }
@@ -488,7 +511,7 @@ impl Resource {
         loc: Location,
     ) -> Result<(), ManagementError> {
         // If this resource is already running, don't bother doing anything:
-        if !self.is_running() {
+        if !self.is_running_on_loc(&client.name) {
             warn!(
                 "Attempting to start resource {} on {}.",
                 self.id,
@@ -499,12 +522,14 @@ impl Resource {
             );
             match self.start(client).await {
                 // Agent replies that the resource was started succesfully.
-                Ok(AgentReply::Success(ocf::Status::Success)) => self.set_running_on_loc(loc),
+                Ok(AgentReply::Success(ocf::Status::Success)) => {
+                    self.set_running_on_loc(&client.name)
+                }
                 // Agent replies that it could not start the resource. This is likely due to a
                 // misconfiguration or other issue that requires admin intervention, so return an
                 // error.
                 Ok(AgentReply::Success(ocf::Status::Error(_, reason))) => {
-                    self.set_status(ResourceStatus::Error(reason));
+                    self.set_status(ResourceStatus::Error(reason), &client.name);
                     return Err(ManagementError::Configuration);
                 }
                 // Agent replies that it could not run the resource management script. This is
@@ -513,7 +538,7 @@ impl Resource {
                 Ok(AgentReply::Error(reason)) => {
                     error!("Warning: Remote agent returned error {reason} when attempting to start resource {}.",
                         self.id);
-                    self.set_status(ResourceStatus::Error(reason));
+                    self.set_status(ResourceStatus::Error(reason), &client.name);
                     return Err(ManagementError::Configuration);
                 }
                 // An RPC error occurred, for example, because the connection timed out or was
@@ -523,7 +548,7 @@ impl Resource {
                         "Error: '{e:?}' when attempting to start resource '{}'.",
                         self.id
                     );
-                    self.set_status(ResourceStatus::Unknown(format!("{e}")));
+                    self.set_status(ResourceStatus::Unknown(format!("{e}")), &client.name);
                     return Err(e.into());
                 }
             };
@@ -545,14 +570,14 @@ impl Resource {
 
         match self.stop(client).await {
             Ok(AgentReply::Success(ocf::Status::Success)) => {
-                self.set_status(ResourceStatus::Stopped);
+                self.set_status(ResourceStatus::Stopped, &client.name);
                 Ok(())
             }
             // Agent replies that it could not stop the resource. This is likely due to a
             // misconfiguration or other issue that requires admin intervention, so return an
             // error.
             Ok(AgentReply::Success(ocf::Status::Error(_, reason))) => {
-                self.set_status(ResourceStatus::Error(reason));
+                self.set_status(ResourceStatus::Error(reason), &client.name);
                 Err(ManagementError::Configuration)
             }
             // Agent replies that it could not run the resource management script. This is
@@ -561,7 +586,7 @@ impl Resource {
             Ok(AgentReply::Error(reason)) => {
                 error!("Warning: Remote agent returned error {reason} when attempting to stop resource {}.",
                     self.id);
-                self.set_status(ResourceStatus::Error(reason));
+                self.set_status(ResourceStatus::Error(reason), &client.name);
                 Err(ManagementError::Configuration)
             }
             // An RPC error occurred, for example, because the connection timed out or was
@@ -571,7 +596,7 @@ impl Resource {
                     "Error: '{e:?}' when attempting to stop resource '{}'.",
                     self.id
                 );
-                self.set_status(ResourceStatus::Unknown(format!("{e}")));
+                self.set_status(ResourceStatus::Unknown(format!("{e}")), &client.name);
                 Err(e.into())
             }
         }
@@ -593,35 +618,41 @@ impl Resource {
         remote_ocf_operation_given_client(self, client, ocf_resource_agent::Operation::Stop).await
     }
 
-    pub fn status(&self) -> ResourceStatus {
-        self.status.lock().unwrap().clone()
+    pub fn status(&self) -> HostStatusMap {
+        self.state.get()
     }
 
-    pub fn set_status(&self, new_status: ResourceStatus) {
-        let mut status = self.status.lock().unwrap();
-        let old_status_copy = status.clone();
-        *status = new_status.clone();
-        std::mem::drop(status);
-        if old_status_copy != new_status {
+    pub fn status_on_host(&self, host: &HostId) -> ResourceStatus {
+        self.status()
+            .get(host)
+            .expect("Host {host} should have a status entry")
+            .clone()
+    }
+
+    pub fn set_status(&self, new_status: ResourceStatus, host: &HostId) {
+        let old_status = self.state.update(new_status.clone(), host);
+
+        if old_status != new_status {
             warn!(
-                "Updating status of resource {} from {:?} to {:?}",
-                self.id, old_status_copy, new_status
+                "Updating status of resource {} on host {} from {:?} to {:?}",
+                self.id, host, old_status, new_status
             )
         }
     }
 
     fn is_running(&self) -> bool {
-        matches!(
-            self.status(),
-            ResourceStatus::RunningOnHome | ResourceStatus::RunningOnAway
-        )
+        self.state
+            .get()
+            .values()
+            .any(|v| *v == ResourceStatus::Running)
     }
 
-    pub fn set_running_on_loc(&self, loc: Location) {
-        match loc {
-            Location::Home => self.set_status(ResourceStatus::RunningOnHome),
-            Location::Away => self.set_status(ResourceStatus::RunningOnAway),
-        };
+    fn is_running_on_loc(&self, host: &HostId) -> bool {
+        self.status_on_host(host) == ResourceStatus::Running
+    }
+
+    pub fn set_running_on_loc(&self, host: &HostId) {
+        self.set_status(ResourceStatus::Running, host);
     }
 
     /// Return a string representation of this resource's parameters in a predictable way.
@@ -640,12 +671,12 @@ impl Resource {
         output
     }
 
-    pub fn set_status_recursive(&self, status: ResourceStatus) {
+    pub fn set_status_recursive(&self, status: ResourceStatus, host: &HostId) {
         for child in self.dependents.iter() {
-            child.set_status_recursive(status.clone());
+            child.set_status_recursive(status.clone(), host);
         }
 
-        self.set_status(status);
+        self.set_status(status, host);
     }
 }
 
@@ -658,7 +689,7 @@ impl Resource {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ResourceStatus {
     /// The resource's status cannot be determined because communication failed between the manager
-    /// service and the remote agent.
+    /// service and the remote agent, or because it hasn't been checked yet.
     Unknown(String),
 
     /// An operation failed in a way that the manager cannot address, and so the resource is
@@ -667,14 +698,17 @@ pub enum ResourceStatus {
     /// state that requires admin intervention.
     Error(String),
 
-    /// The resource is not running anywhere.
+    /// The resource is not running.
     Stopped,
 
-    /// The resource is running on its failover node.
-    RunningOnAway,
+    /// The resource is running.
+    Running,
+}
 
-    /// The resource is running on its home node.
-    RunningOnHome,
+impl Default for ResourceStatus {
+    fn default() -> Self {
+        ResourceStatus::Unknown("Manager is starting up".to_string())
+    }
 }
 
 impl ResourceStatus {
@@ -725,13 +759,6 @@ mod tests {
         assert_eq!(
             ResourceStatus::get_worst(vec![].into_iter()),
             ResourceStatus::Unknown("".to_string()),
-        );
-
-        assert_eq!(
-            ResourceStatus::get_worst(
-                vec![ResourceStatus::RunningOnHome, ResourceStatus::RunningOnAway].into_iter()
-            ),
-            ResourceStatus::RunningOnAway,
         );
     }
 }

--- a/src/test_env/ha.rs
+++ b/src/test_env/ha.rs
@@ -255,6 +255,8 @@ impl Assert {
     #[allow(clippy::collapsible_match, clippy::single_match)]
     fn check(&self, status: &http::ClusterJson) {
         for res in &status.resources {
+            let (resource_status, _) = res.single_host_status();
+
             let check = match self.target {
                 Target::AllResources => true,
                 Target::ResourceGroup0 => res.id.contains("0"),
@@ -266,10 +268,10 @@ impl Assert {
             if check {
                 match &self.what {
                     AssertKind::Status(status) => {
-                        if &res.status != status {
+                        if resource_status != status {
                             panic!(
                                 "Expected status '{}', got '{}', for resource '{}'",
-                                status, res.status, res.id
+                                status, resource_status, res.id
                             );
                         }
                     }


### PR DESCRIPTION
This updates the representation of the resource status to be more flexible / generic / robust.

No user visible changes are intended, this is just to enable future changes to allow non-exclusive resources and/or resources that can run on failover groups larger than a pair.