### PR TITLE
Resource status cleanup

### DIFF
--- a/src/host/ha.rs
+++ b/src/host/ha.rs
@@ -276,7 +276,7 @@ impl Host {
                     // If the host is known down (i.e., was previously fenced), then we know that
                     // the resource is stopped, and any requests to manage it here can be bounced
                     // back to the partner to manage it there.
-                    if rg.is_stopped_at_location(message.resource_group.location) {
+                    if rg.is_stopped_at_location(&self.id()) {
                         self.send_message_to_partner_delayed(
                             message.resource_group,
                             Message::ManageResourceGroup,
@@ -660,11 +660,6 @@ impl Host {
         warn!("Host {} has been powered off.", self.id());
 
         for token in tokens_to_send {
-            let rg = cluster.get_resource_group(&token.id);
-            // We know resource is stopped if fencing succeeded:
-            rg.root
-                .set_status_recursive(ResourceStatus::Stopped, &self.id());
-
             self.send_message_to_partner(token, Message::ManageResourceGroup)
                 .await;
         }
@@ -672,11 +667,13 @@ impl Host {
 
     fn update_resource_groups_stopped(&self, cluster: &Cluster) {
         for rg in cluster.host_home_resource_groups(self) {
-            rg.has_been_stopped(&self.id());
+            rg.root
+                .set_status_recursive(ResourceStatus::Stopped, &self.id());
         }
 
         for rg in cluster.host_home_resource_groups(self.ha_failover_partner()) {
-            rg.has_been_stopped(&self.id());
+            rg.root
+                .set_status_recursive(ResourceStatus::Stopped, &self.id());
         }
     }
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -84,40 +84,9 @@ pub struct ResourceGroup {
     pub root: Resource,
     managed: Mutex<bool>,
     args: manager::Cli,
-    home_node: HostKnowledge,
-    failover_node: Option<HostKnowledge>,
+    home_node: Arc<Host>,
+    failover_node: Option<Arc<Host>>,
 }
-
-#[derive(Debug)]
-struct HostKnowledge {
-    host: Arc<Host>,
-    state: Mutex<State>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-enum State {
-    Running,
-    Stopped,
-    Unknown,
-}
-
-impl HostKnowledge {
-    fn new(host: Arc<Host>) -> Self {
-        Self {
-            host,
-            state: Mutex::new(State::Unknown),
-        }
-    }
-
-    fn state(&self) -> State {
-        *self.state.lock().unwrap()
-    }
-
-    fn set_state(&self, state: State) {
-        *self.state.lock().unwrap() = state;
-    }
-}
-
 impl ResourceGroup {
     pub fn new(
         root: Resource,
@@ -129,8 +98,8 @@ impl ResourceGroup {
             root,
             managed: Mutex::new(true),
             args,
-            home_node: HostKnowledge::new(home_node),
-            failover_node: failover_node.map(HostKnowledge::new),
+            home_node,
+            failover_node,
         }
     }
 
@@ -139,11 +108,11 @@ impl ResourceGroup {
     }
 
     pub fn home_node(&self) -> &Arc<Host> {
-        &self.home_node.host
+        &self.home_node
     }
 
     pub fn failover_node(&self) -> Option<&Arc<Host>> {
-        self.failover_node.as_ref().map(|h| &h.host)
+        self.failover_node.as_ref()
     }
 
     /// The host-driven resource management loop manages resources on a given location until
@@ -189,28 +158,12 @@ impl ResourceGroup {
 
     /// Attempt to start the resources in this resource group on the given location.
     async fn start_resources(&self, client: &Client, loc: Location) -> Result<(), ManagementError> {
-        let res = self.root.start_if_needed_recursive(client, loc).await;
-
-        match res {
-            Ok(()) => self.set_host_state(State::Running, &client.name),
-            Err(ManagementError::Connection) => self.set_host_state(State::Unknown, &client.name),
-            _ => {}
-        };
-
-        res
+        self.root.start_if_needed_recursive(client, loc).await
     }
 
     /// Attempt to stop the resources in this resource group.
     pub async fn stop_resources(&self, client: &Client) -> Result<(), ManagementError> {
-        let res = self.root.stop_recursive(client).await;
-
-        match res {
-            Ok(()) => self.set_host_state(State::Stopped, &client.name),
-            Err(ManagementError::Connection) => self.set_host_state(State::Unknown, &client.name),
-            _ => {}
-        }
-
-        res
+        self.root.stop_recursive(client).await
     }
 
     pub fn get_overall_status_on_host(&self, host: &HostId) -> ResourceStatus {
@@ -239,64 +192,33 @@ impl ResourceGroup {
         // its state MUST be revalidated before the manager can take any actions on it. Therefore,
         // clear any out of date knowledge on whether it was known to be running somewhere.
         if !*managed_status && managed {
-            *self.home_node.state.lock().unwrap() = State::Unknown;
-            if let Some(ref failover_node) = self.failover_node {
-                *failover_node.state.lock().unwrap() = State::Unknown;
+            self.root.set_status_recursive(
+                ResourceStatus::Unknown("Manager is beginning management of resource.".to_string()),
+                &self.home_node.id(),
+            );
+            if let Some(failover_node) = &self.failover_node {
+                self.root.set_status_recursive(
+                    ResourceStatus::Unknown(
+                        "Manager is beginning management of resource.".to_string(),
+                    ),
+                    &failover_node.id(),
+                );
             }
         }
 
         *managed_status = managed;
     }
 
-    pub fn has_been_stopped(&self, host: &HostId) {
-        self.set_host_state(State::Stopped, host);
-    }
-
     pub fn is_running_nowhere(&self) -> bool {
-        self.home_node.state() == State::Stopped
-            && self.failover_node.as_ref().unwrap().state() == State::Stopped
+        self.root
+            .state
+            .get()
+            .values()
+            .all(|st| *st == ResourceStatus::Stopped)
     }
 
-    pub fn is_stopped_at_location(&self, loc: Location) -> bool {
-        let state = match loc {
-            Location::Home => self.home_node.state(),
-            Location::Away => self.failover_node.as_ref().expect("must be set").state(),
-        };
-
-        state == State::Stopped
-    }
-
-    fn set_host_state(&self, state: State, host_id: &HostId) {
-        let host = if host_id == &self.home_node.host.id() {
-            &self.home_node
-        } else {
-            let failover_host = self
-                .failover_node
-                .as_ref()
-                .expect("Failover node must be set.");
-            if host_id != &failover_host.host.id() {
-                panic!(
-                    "Unexpeced host id: {host_id} for setting resource state of {}",
-                    self.id()
-                );
-            }
-            failover_host
-        };
-
-        host.set_state(state);
-
-        self.assert_knowledge_invariant();
-    }
-
-    fn assert_knowledge_invariant(&self) {
-        if let Some(ref failover_node) = self.failover_node {
-            let home_state = self.home_node.state();
-            let failover_state = failover_node.state();
-            if home_state == State::Running && failover_state == State::Running {
-                panic!("Resource group {} violated invariant: system believes it to be running on both nodes.",
-                    self.id());
-            }
-        }
+    pub fn is_stopped_at_location(&self, id: &HostId) -> bool {
+        self.root.status_on_host(id) == ResourceStatus::Stopped
     }
 
     fn assert_not_running_elsewhere(&self, host: &HostId) {
@@ -337,7 +259,6 @@ impl ResourceGroup {
 
         get_worst_error(future::join_all(futures).await.into_iter()).inspect_err(|e| {
             if matches!(e, ManagementError::Connection) {
-                self.set_host_state(State::Unknown, &client.name);
                 self.root.set_status_recursive(
                     ResourceStatus::Unknown("Connection to remote host lost.".to_string()),
                     &client.name,
@@ -346,10 +267,8 @@ impl ResourceGroup {
         })?;
 
         if self.root.is_running_on_loc(&client.name) {
-            self.set_host_state(State::Running, &client.name);
             Ok(true)
         } else {
-            self.set_host_state(State::Stopped, &client.name);
             Ok(false)
         }
     }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -333,7 +333,7 @@ impl ResourceGroup {
     pub async fn update_resources(&self, client: &Client) -> Result<bool, ManagementError> {
         self.assert_not_running_elsewhere(&client.name);
 
-        let futures = self.resources().map(|r| r.update_status(client));
+        let futures = self.resources().map(|r| r.check_and_update_status(client));
 
         get_worst_error(future::join_all(futures).await.into_iter()).inspect_err(|e| {
             if matches!(e, ManagementError::Connection) {
@@ -502,7 +502,7 @@ impl Resource {
     }
 
     /// This method checks if the resource is running on the system connected via the given Client.
-    pub async fn update_status(&self, client: &Client) -> Result<(), ManagementError> {
+    async fn check_and_update_status(&self, client: &Client) -> Result<(), ManagementError> {
         match self.monitor(client).await {
             Ok(AgentReply::Success(ocf::Status::Success)) => {
                 self.set_running_on_loc(&client.name);

--- a/src/test_env/ha.rs
+++ b/src/test_env/ha.rs
@@ -148,7 +148,7 @@ impl HaEnvironment {
 
     fn get_status(&self) -> http::ClusterJson {
         let status = commands::status::get_status(Some(&self.socket_path())).unwrap();
-        eprintln!("{status:?}");
+        eprintln!("{status:#?}");
         status
     }
 


### PR DESCRIPTION
The resource status information stored at the resource group level was redundant with the status information stored at the resource level.

This uses the resource level information as the single source and gets rid of the redundant info.