### PR TITLE
Use privileged ports as default for communication between manager and remotes

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -4,10 +4,15 @@
 use std::{
     collections::{HashMap, HashSet},
     env,
+    io::ErrorKind,
+    net::SocketAddr,
     sync::Arc,
 };
 
-use {futures::future, rustls::pki_types::ServerName, tokio_rustls::TlsConnector};
+use {
+    futures::future, rustls::pki_types::ServerName, tokio::net::TcpSocket,
+    tokio_rustls::TlsConnector,
+};
 
 use crate::{
     config, handled_error,
@@ -17,6 +22,26 @@ use crate::{
     state::{Record, State},
     Handle, HandledResult,
 };
+
+/// ClusterAddress holds a bound socket that should stay bound for the lifetime of this object, but
+/// does not need to be referenced, as well as the corresponding address that can continually be
+/// used to make connections.
+pub struct ClusterAddress {
+    address: SocketAddr,
+    _socket: TcpSocket,
+}
+
+impl ClusterAddress {
+    pub fn new() -> Self {
+        let (address, _socket) = reserve_local_privileged_port().unwrap();
+        Self { address, _socket }
+    }
+
+    /// Get a string representation of the address.
+    pub fn address(&self) -> SocketAddr {
+        self.address
+    }
+}
 
 /// Cluster is the model used to represent the dynamic state of a cluster in memory.
 /// Unlike the persistent model which views a cluster as made up of nodes, which own services,
@@ -40,6 +65,10 @@ pub struct Cluster {
     /// File to use to store/load cluster state. This must be specified on the manager side where
     /// state must be considered; otherwise, this does not need to be specified.
     state: Option<State>,
+
+    /// The address used to connect to clients through. Currently, this is only needed when using
+    /// privileged ports (the default), since they must be manually assigned.
+    pub address: Option<ClusterAddress>,
 
     pub tls_args: Option<TlsArgs>,
 }
@@ -168,6 +197,12 @@ impl Cluster {
             None
         };
 
+        let address = if !args.use_insecure_port {
+            Some(ClusterAddress::new())
+        } else {
+            None
+        };
+
         for rg in &config.resource_groups {
             if rg.failover_hosts.len() > 1 {
                 eprintln!(
@@ -179,7 +214,7 @@ impl Cluster {
             }
         }
 
-        let new = Cluster::from_config2(&config, args.clone(), state, tls_args);
+        let new = Cluster::from_config2(&config, args.clone(), state, address, tls_args);
 
         if new.resource_groups.iter().any(|rg| rg.root.count > 1) {
             eprintln!("Config has a shared root resource, which is not supported.");
@@ -203,6 +238,7 @@ impl Cluster {
         config: &config::Config,
         args: manager::Cli,
         state: Option<State>,
+        address: Option<ClusterAddress>,
         tls_args: Option<TlsArgs>,
     ) -> Self {
         let hosts: HashMap<_, _> = config
@@ -317,6 +353,7 @@ impl Cluster {
             args,
             failover,
             state,
+            address,
             tls_args,
         }
     }
@@ -378,4 +415,21 @@ pub fn get_failover_partner<'pairs>(
         }
     }
     None
+}
+
+/// Attempt to create a TCP socket using a local address and privileged port <=1024.
+fn reserve_local_privileged_port() -> HandledResult<(SocketAddr, TcpSocket)> {
+    for i in 500..=1024 {
+        let addr = format!("127.0.0.1:{i}").parse().unwrap();
+        let socket = TcpSocket::new_v4().unwrap();
+        socket.set_reuseaddr(true).unwrap();
+        match socket.bind(addr) {
+            Ok(()) => return Ok((addr, socket)),
+            Err(e) if e.kind() == ErrorKind::AddrInUse => continue,
+            Err(other) => eprintln!("{other}"),
+        }
+    }
+
+    eprintln!("Could not bind to a local privileged port. Add the `--use-insecure-port` manager option if you want to bind to an unprivileged port instead.");
+    handled_error()
 }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -420,7 +420,7 @@ pub fn get_failover_partner<'pairs>(
 /// Attempt to create a TCP socket using a local address and privileged port <=1024.
 fn reserve_local_privileged_port() -> HandledResult<(SocketAddr, TcpSocket)> {
     for i in 500..=1024 {
-        let addr = format!("127.0.0.1:{i}").parse().unwrap();
+        let addr = format!("0.0.0.0:{i}").parse().unwrap();
         let socket = TcpSocket::new_v4().unwrap();
         socket.set_reuseaddr(true).unwrap();
         match socket.bind(addr) {

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -23,18 +23,18 @@ use crate::{
     Handle, HandledResult,
 };
 
-/// ClusterAddress holds a bound socket that should stay bound for the lifetime of this object, but
-/// does not need to be referenced, as well as the corresponding address that can continually be
-/// used to make connections.
-pub struct ClusterAddress {
+/// RpcSourceAddress holds the local socket address used to make connections to the remote clients.
+pub struct RpcSourceAddress {
+    /// The local socket address used as the source address in connections to remote clients.
     address: SocketAddr,
+    /// This socket is held open to "reserve" the address for the lifetime of this object.
     _socket: TcpSocket,
 }
 
-impl ClusterAddress {
-    pub fn new() -> Self {
-        let (address, _socket) = reserve_local_privileged_port().unwrap();
-        Self { address, _socket }
+impl RpcSourceAddress {
+    pub fn new() -> HandledResult<Self> {
+        let (address, _socket) = reserve_local_privileged_port()?;
+        Ok(Self { address, _socket })
     }
 
     /// Get a string representation of the address.
@@ -68,7 +68,7 @@ pub struct Cluster {
 
     /// The address used to connect to clients through. Currently, this is only needed when using
     /// privileged ports (the default), since they must be manually assigned.
-    pub address: Option<ClusterAddress>,
+    pub address: Option<RpcSourceAddress>,
 
     pub tls_args: Option<TlsArgs>,
 }
@@ -198,7 +198,7 @@ impl Cluster {
         };
 
         let address = if !args.use_insecure_port {
-            Some(ClusterAddress::new())
+            Some(RpcSourceAddress::new()?)
         } else {
             None
         };
@@ -238,7 +238,7 @@ impl Cluster {
         config: &config::Config,
         args: manager::Cli,
         state: Option<State>,
-        address: Option<ClusterAddress>,
+        address: Option<RpcSourceAddress>,
         tls_args: Option<TlsArgs>,
     ) -> Self {
         let hosts: HashMap<_, _> = config

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -4,7 +4,7 @@
 use std::{
     collections::{HashMap, HashSet},
     env,
-    io::ErrorKind,
+    io::{self, ErrorKind},
     net::SocketAddr,
     sync::Arc,
 };
@@ -419,17 +419,19 @@ pub fn get_failover_partner<'pairs>(
 
 /// Attempt to create a TCP socket using a local address and privileged port <=1024.
 fn reserve_local_privileged_port() -> HandledResult<(SocketAddr, TcpSocket)> {
-    for i in 500..=1024 {
+    let mut last_err = io::Error::from(ErrorKind::Other);
+    for i in 500..1024 {
         let addr = format!("0.0.0.0:{i}").parse().unwrap();
         let socket = TcpSocket::new_v4().unwrap();
         socket.set_reuseaddr(true).unwrap();
         match socket.bind(addr) {
             Ok(()) => return Ok((addr, socket)),
             Err(e) if e.kind() == ErrorKind::AddrInUse => continue,
-            Err(other) => eprintln!("{other}"),
+            Err(other) => last_err = other,
         }
     }
 
     eprintln!("Could not bind to a local privileged port. Add the `--use-insecure-port` manager option if you want to bind to an unprivileged port instead.");
+    eprintln!("Last error detected: {last_err}");
     handled_error()
 }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -79,6 +79,13 @@ pub struct TlsArgs {
     pub domain: ServerName<'static>,
 }
 
+fn host_from_config_host(config_host: &config::Host) -> HandledResult<(String, Arc<Host>)> {
+    match Host::from_config(config_host) {
+        Ok(h) => Ok((config_host.hostname.clone(), Arc::new(h))),
+        Err(_) => handled_error(),
+    }
+}
+
 impl Cluster {
     /// Apply a state Delta to this Cluster's Hosts.
     pub fn apply_state(&self) {
@@ -214,7 +221,7 @@ impl Cluster {
             }
         }
 
-        let new = Cluster::from_config2(&config, args.clone(), state, address, tls_args);
+        let new = Cluster::from_config2(&config, args.clone(), state, address, tls_args)?;
 
         if new.resource_groups.iter().any(|rg| rg.root.count > 1) {
             eprintln!("Config has a shared root resource, which is not supported.");
@@ -240,12 +247,10 @@ impl Cluster {
         state: Option<State>,
         address: Option<RpcSourceAddress>,
         tls_args: Option<TlsArgs>,
-    ) -> Self {
-        let hosts: HashMap<_, _> = config
-            .hosts
-            .iter()
-            .map(|h| (h.hostname.clone(), Arc::new(Host::from_config(h))))
-            .collect();
+    ) -> HandledResult<Self> {
+        let hosts: Result<HashMap<_, _>, _> =
+            config.hosts.iter().map(host_from_config_host).collect();
+        let hosts = hosts?;
 
         // Set failover partners:
         let failover_partners = config.get_failover_partners();
@@ -347,7 +352,7 @@ impl Cluster {
         // right value:
         let hosts = hosts.into_values().map(|host| (host.id(), host)).collect();
 
-        Self {
+        Ok(Self {
             resource_groups,
             hosts,
             args,
@@ -355,7 +360,7 @@ impl Cluster {
             state,
             address,
             tls_args,
-        }
+        })
     }
 
     /// Write a Record entry into the Cluster's statefile.

--- a/src/halo_capnp.rs
+++ b/src/halo_capnp.rs
@@ -91,52 +91,30 @@ fn prep_request(request: &mut OperationRequest, res: &Resource, op: ocf_resource
     }
 }
 
-/// Attempt to establish a TCP stream to the given socket address from the source address.
-async fn tcp_try_connect_one(
+/// Create a SocketAddr from a string slice.
+fn str2sockaddr(addr: &str) -> io::Result<std::net::SocketAddr> {
+    addr.parse().map_err(|e| {
+        log::warn!("could not parse as valid tcp address: '{addr}': {e}");
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid tcp address '{addr}'"),
+        )
+    })
+}
+
+/// Attempt to establish a TCP stream to the given socket address from the given source address.
+async fn tcp_try_connect(
     from_addr: std::net::SocketAddr,
     to_addr: std::net::SocketAddr,
 ) -> io::Result<tokio::net::TcpStream> {
     let sock = tokio::net::TcpSocket::new_v4().inspect_err(|e| {
-        log::debug!("could not create new tcpv4 socket: {e}");
+        log::warn!("could not create new tcpv4 socket: {e}");
     })?;
     sock.set_reuseaddr(true).unwrap();
-    sock.bind(from_addr).map_err(|e| {
-        log::debug!("could not bind to address {from_addr}: {e}");
-        e
+    sock.bind(from_addr).inspect_err(|e| {
+        log::warn!("could not bind to address '{from_addr}': {e}");
     })?;
-    log::debug!("connecting to address: {to_addr}");
     sock.connect(to_addr).await
-}
-
-/// Attempt to establish a TCP stream to the given TCP address that may resolve to multiple IP addresses.
-async fn tcp_try_connect(
-    from_addr: std::net::SocketAddr,
-    to_addr: &str,
-) -> io::Result<tokio::net::TcpStream> {
-    let to_addrs = tokio::net::lookup_host(to_addr).await.inspect_err(|e| {
-        log::debug!("cannot parse host '{to_addr}' as an address: {e}");
-    })?;
-    let mut stream = None;
-    for addr in to_addrs {
-        match tcp_try_connect_one(from_addr, addr).await {
-            Ok(s) => {
-                stream = Some(s);
-                break;
-            }
-            Err(e) => {
-                log::debug!("could not connect to host '{addr}': {e}");
-            }
-        }
-    }
-    let stream = stream.ok_or_else(|| {
-        log::debug!("could not connect to any address for host '{to_addr}'");
-        io::Error::new(
-            io::ErrorKind::AddrNotAvailable,
-            format!("connection failed to host '{to_addr}'"),
-        )
-    })?;
-
-    Ok(stream)
 }
 
 pub async fn get_client(
@@ -148,7 +126,9 @@ pub async fn get_client(
         let Some(cluster_sock) = &cluster.address else {
             panic!("cluster.address should be Some when cluster.args.use_insecure_port == false");
         };
-        tcp_try_connect(cluster_sock.address(), address).await?
+        let from_addr = cluster_sock.address();
+        let to_addr = str2sockaddr(address)?;
+        tcp_try_connect(from_addr, to_addr).await?
     } else {
         tokio::net::TcpStream::connect(address).await?
     };

--- a/src/halo_capnp.rs
+++ b/src/halo_capnp.rs
@@ -91,14 +91,70 @@ fn prep_request(request: &mut OperationRequest, res: &Resource, op: ocf_resource
     }
 }
 
+/// Attempt to establish a TCP stream to the given socket address from the source address.
+async fn tcp_try_connect_one(
+    from_addr: std::net::SocketAddr,
+    to_addr: std::net::SocketAddr,
+) -> io::Result<tokio::net::TcpStream> {
+    let sock = tokio::net::TcpSocket::new_v4().inspect_err(|e| {
+        log::debug!("could not create new tcpv4 socket: {e}");
+    })?;
+    sock.set_reuseaddr(true).unwrap();
+    sock.bind(from_addr).map_err(|e| {
+        log::debug!("could not bind to address {from_addr}: {e}");
+        e
+    })?;
+    log::debug!("connecting to address: {to_addr}");
+    sock.connect(to_addr).await
+}
+
+/// Attempt to establish a TCP stream to the given TCP address that may resolve to multiple IP addresses.
+async fn tcp_try_connect(
+    from_addr: std::net::SocketAddr,
+    to_addr: &str,
+) -> io::Result<tokio::net::TcpStream> {
+    let to_addrs = tokio::net::lookup_host(to_addr).await.inspect_err(|e| {
+        log::debug!("cannot parse host '{to_addr}' as an address: {e}");
+    })?;
+    let mut stream = None;
+    for addr in to_addrs {
+        match tcp_try_connect_one(from_addr, addr).await {
+            Ok(s) => {
+                stream = Some(s);
+                break;
+            }
+            Err(e) => {
+                log::debug!("could not connect to host '{addr}': {e}");
+            }
+        }
+    }
+    let stream = stream.ok_or_else(|| {
+        log::debug!("could not connect to any address for host '{to_addr}'");
+        io::Error::new(
+            io::ErrorKind::AddrNotAvailable,
+            format!("connection failed to host '{to_addr}'"),
+        )
+    })?;
+
+    Ok(stream)
+}
+
 pub async fn get_client(
     address: &str,
-    tls_args: Option<&cluster::TlsArgs>,
+    cluster: &cluster::Cluster,
 ) -> io::Result<ocf_resource_agent::Client> {
-    let stream = tokio::net::TcpStream::connect(address).await?;
+    // Bind to specific cluster address if it has been specified.
+    let stream = if !cluster.args.use_insecure_port {
+        let Some(cluster_sock) = &cluster.address else {
+            panic!("cluster.address should be Some when cluster.args.use_insecure_port == false");
+        };
+        tcp_try_connect(cluster_sock.address(), address).await?
+    } else {
+        tokio::net::TcpStream::connect(address).await?
+    };
     stream.set_nodelay(true).expect("setting nodelay failed.");
 
-    match tls_args {
+    match &cluster.tls_args {
         Some(args) => {
             // Perform mtls handshake
             let mtls_stream = args

--- a/src/halo_capnp.rs
+++ b/src/halo_capnp.rs
@@ -91,17 +91,6 @@ fn prep_request(request: &mut OperationRequest, res: &Resource, op: ocf_resource
     }
 }
 
-/// Create a SocketAddr from a string slice.
-fn str2sockaddr(addr: &str) -> io::Result<std::net::SocketAddr> {
-    addr.parse().map_err(|e| {
-        log::warn!("could not parse as valid tcp address: '{addr}': {e}");
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("invalid tcp address '{addr}'"),
-        )
-    })
-}
-
 /// Attempt to establish a TCP stream to the given socket address from the given source address.
 async fn tcp_try_connect(
     from_addr: std::net::SocketAddr,
@@ -118,7 +107,7 @@ async fn tcp_try_connect(
 }
 
 pub async fn get_client(
-    address: &str,
+    client_addr: std::net::SocketAddr,
     cluster: &cluster::Cluster,
 ) -> io::Result<ocf_resource_agent::Client> {
     // Bind to specific cluster address if it has been specified.
@@ -127,10 +116,9 @@ pub async fn get_client(
             panic!("cluster.address should be Some when cluster.args.use_insecure_port == false");
         };
         let from_addr = cluster_sock.address();
-        let to_addr = str2sockaddr(address)?;
-        tcp_try_connect(from_addr, to_addr).await?
+        tcp_try_connect(from_addr, client_addr).await?
     } else {
-        tokio::net::TcpStream::connect(address).await?
+        tokio::net::TcpStream::connect(client_addr).await?
     };
     stream.set_nodelay(true).expect("setting nodelay failed.");
 

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -5,6 +5,7 @@ use std::{
     fmt,
     future::Future,
     io,
+    net::IpAddr,
     pin::Pin,
     rc::Rc,
     sync::{Arc, OnceLock},
@@ -41,6 +42,7 @@ impl std::fmt::Display for HostId {
 #[derive(Debug, Clone)]
 struct HostAddress {
     name: String,
+    ip: IpAddr,
     port: u16,
 }
 
@@ -132,13 +134,22 @@ impl Host {
     pub fn new(raw_name: String, fence_agent: Option<FenceAgent>) -> Self {
         let (name, port) = Self::get_host_port(&raw_name);
         let (sender, receiver) = mpsc::channel(1024);
+        let port = match port {
+            Some(p) => p,
+            None => crate::remote_port(),
+        };
+        use std::net::ToSocketAddrs;
+        let ip = (name, port)
+            .to_socket_addrs()
+            .unwrap()
+            .nth(0)
+            .expect(format!("could not resolve host: '{name}'").as_str())
+            .ip();
         Host {
             address: HostAddress {
                 name: name.to_string(),
-                port: match port {
-                    Some(p) => p,
-                    None => crate::remote_port(),
-                },
+                ip,
+                port,
             },
             raw_name,
             fence_agent,
@@ -220,12 +231,16 @@ impl Host {
         &self.address.name
     }
 
+    pub fn ip(&self) -> &IpAddr {
+        &self.address.ip
+    }
+
     pub fn port(&self) -> u16 {
         self.address.port
     }
 
     pub fn address(&self) -> String {
-        format!("{}:{}", self.name(), self.port())
+        format!("{}:{}", self.ip(), self.port())
     }
 
     /// Get a unique identifier for this host. Typically, this will just be the hostname, but in

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -270,7 +270,7 @@ impl Host {
     }
 
     async fn get_client(&self, cluster: &Cluster) -> io::Result<Client> {
-        let client = halo_capnp::get_client(&self.address(), cluster.tls_args.as_ref()).await;
+        let client = halo_capnp::get_client(&self.address(), cluster).await;
         match client {
             Ok(_) => self.set_connected(true),
             Err(_) => self.set_connected(false),

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -5,7 +5,7 @@ use std::{
     fmt,
     future::Future,
     io,
-    net::IpAddr,
+    net::{IpAddr, ToSocketAddrs},
     pin::Pin,
     rc::Rc,
     sync::{Arc, OnceLock},
@@ -138,7 +138,6 @@ impl Host {
             Some(p) => p,
             None => crate::remote_port(),
         };
-        use std::net::ToSocketAddrs;
         let ip = (name, port)
             .to_socket_addrs()
             .unwrap()

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -243,6 +243,10 @@ impl Host {
         self.address.port
     }
 
+    pub fn sockaddr(&self) -> SocketAddr {
+        self.address.addr
+    }
+
     pub fn address(&self) -> String {
         format!("{}:{}", self.name(), self.port())
     }
@@ -289,7 +293,7 @@ impl Host {
     }
 
     async fn get_client(&self, cluster: &Cluster) -> io::Result<Client> {
-        let client = halo_capnp::get_client(&self.address(), cluster).await;
+        let client = halo_capnp::get_client(self.sockaddr(), cluster).await;
         match client {
             Ok(_) => self.set_connected(true),
             Err(_) => self.set_connected(false),

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -5,7 +5,7 @@ use std::{
     fmt,
     future::Future,
     io,
-    net::{IpAddr, ToSocketAddrs},
+    net::{SocketAddr, ToSocketAddrs},
     pin::Pin,
     rc::Rc,
     sync::{Arc, OnceLock},
@@ -19,6 +19,7 @@ use {
 use crate::{
     cluster::Cluster,
     halo_capnp::{self, *},
+    handled_error,
     resource::{Location, ResourceId},
     state::{Event, Record},
     Handle, HandledResult,
@@ -42,7 +43,7 @@ impl std::fmt::Display for HostId {
 #[derive(Debug, Clone)]
 struct HostAddress {
     name: String,
-    ip: IpAddr,
+    addr: SocketAddr,
     port: u16,
 }
 
@@ -99,6 +100,19 @@ pub struct Client {
     pub name: HostId,
 }
 
+/// Create a SocketAddr given a resolvable hostname and port. The hostname will try to be resolved
+/// to the first IP address that resolves before becoming a component of the SocketAddr.
+pub fn resolve_host_address(name: &str, port: u16) -> HandledResult<SocketAddr> {
+    let maybe_sockaddr = (name, port).to_socket_addrs().unwrap().next();
+    match maybe_sockaddr {
+        Some(sockaddr) => Ok(sockaddr),
+        None => {
+            eprintln!("could not resolve host: '{name}'");
+            handled_error()
+        }
+    }
+}
+
 /// A server on which services can run.
 #[derive(Debug)]
 pub struct Host {
@@ -131,23 +145,18 @@ pub struct Host {
 }
 
 impl Host {
-    pub fn new(raw_name: String, fence_agent: Option<FenceAgent>) -> Self {
+    pub fn new(raw_name: String, fence_agent: Option<FenceAgent>) -> HandledResult<Self> {
         let (name, port) = Self::get_host_port(&raw_name);
         let (sender, receiver) = mpsc::channel(1024);
         let port = match port {
             Some(p) => p,
             None => crate::remote_port(),
         };
-        let ip = (name, port)
-            .to_socket_addrs()
-            .unwrap()
-            .nth(0)
-            .expect(format!("could not resolve host: '{name}'").as_str())
-            .ip();
-        Host {
+        let addr = resolve_host_address(name, port)?;
+        Ok(Host {
             address: HostAddress {
                 name: name.to_string(),
-                ip,
+                addr,
                 port,
             },
             raw_name,
@@ -159,16 +168,16 @@ impl Host {
             connected: std::sync::Mutex::new(false),
             fence_attempted: std::sync::Mutex::new(false),
             fence_event: std::sync::Mutex::new(None),
-        }
+        })
     }
 
     /// Create a Host object from a given config::Host object.
-    pub fn from_config(config: &crate::config::Host) -> Self {
+    pub fn from_config(config: &crate::config::Host) -> HandledResult<Self> {
         let fence_agent = FenceAgent::from_config(config);
         Host::new(config.hostname.clone(), fence_agent)
     }
 
-    /// Given a string that may be of the form "<address>:port number>", split it out into the address
+    /// Given a string that may be of the form "<address>:<port number>", split it out into the address
     /// and port number portions.
     fn get_host_port(host_str: &str) -> (&str, Option<u16>) {
         let mut split = host_str.split(':');
@@ -230,16 +239,12 @@ impl Host {
         &self.address.name
     }
 
-    pub fn ip(&self) -> &IpAddr {
-        &self.address.ip
-    }
-
     pub fn port(&self) -> u16 {
         self.address.port
     }
 
     pub fn address(&self) -> String {
-        format!("{}:{}", self.ip(), self.port())
+        format!("{}:{}", self.name(), self.port())
     }
 
     /// Get a unique identifier for this host. Typically, this will just be the hostname, but in

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -20,6 +20,10 @@ pub struct Cli {
     #[arg(long)]
     pub socket: Option<String>,
 
+    /// Use a tcp port >1024 to communicate with hosts.
+    #[arg(long)]
+    pub use_insecure_port: bool,
+
     /// Location of the file used to store the persistent event log.
     #[arg(long)]
     pub statefile: Option<String>,

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -33,6 +33,10 @@ pub struct Cli {
     #[arg(long)]
     pub port: Option<u16>,
 
+    /// Accept connections only from privileged clients.
+    #[arg(long)]
+    pub allow_insecure_ports: bool,
+
     #[arg(short, long)]
     pub verbose: bool,
 
@@ -98,6 +102,7 @@ async fn __agent_main(args: Cli, addr: &str) -> HandledResult<()> {
     } else {
         None
     };
+    let allow_insecure_ports = args.allow_insecure_ports;
 
     tokio::task::LocalSet::new()
         .run_until(async move {
@@ -111,10 +116,17 @@ async fn __agent_main(args: Cli, addr: &str) -> HandledResult<()> {
                 capnp_rpc::new_client(OcfResourceAgentImpl { cli: args });
 
             loop {
-                let Ok((stream, _)) = listener.accept().await else {
+                let Ok((stream, socket)) = listener.accept().await else {
                     warn!("Error accepting connection. Dropping connection.");
                     continue;
                 };
+                if !allow_insecure_ports {
+                    let port = socket.port();
+                    if port >= 1024 {
+                        warn!("Rejecting connection from insecure port {port}");
+                        continue;
+                    }
+                }
                 let Ok(_) = stream.set_nodelay(true) else {
                     warn!("Error setting nodelay on connection. Dropping connection.");
                     continue;

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -33,7 +33,7 @@ pub struct Cli {
     #[arg(long)]
     pub port: Option<u16>,
 
-    /// Accept connections only from privileged clients.
+    /// Allow connections from unprivileged clients.
     #[arg(long)]
     pub allow_insecure_ports: bool,
 

--- a/src/test_env/mod.rs
+++ b/src/test_env/mod.rs
@@ -206,6 +206,7 @@ impl TestEnvironment {
                     handle: std::process::Command::new(&self.agent_binary_path)
                         .args(vec![
                             "--verbose",
+                            "--allow-insecure-ports",
                             "--test-id",
                             &agent.id.as_ref().unwrap_or(&self.test_id),
                         ])
@@ -255,6 +256,7 @@ impl TestEnvironment {
             &socket_path,
             "--sleep-time",
             "500",
+            "--use-insecure-port",
         ];
 
         if manage_resources {

--- a/src/test_env/mod.rs
+++ b/src/test_env/mod.rs
@@ -173,6 +173,7 @@ impl TestEnvironment {
         manager::Cli {
             config: Some(config_path),
             socket: Some(socket_path),
+            use_insecure_port: true,
             statefile: Some(statefile_path),
             mtls: false,
             verbose: false,

--- a/src/test_env/mod.rs
+++ b/src/test_env/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     config::{self, Config},
     manager,
     resource::Resource,
+    HandledResult,
 };
 
 pub mod ha;
@@ -16,6 +17,16 @@ pub mod ha;
 /// full path to the test directory.
 pub fn test_path(path: &str) -> String {
     std::env::var("CARGO_MANIFEST_DIR").unwrap() + "/tests/" + path
+}
+
+/// Similar to Cluster::from_config(), save for using a port > 1023 for client communication.
+pub fn cluster_from_config(config: Option<String>) -> HandledResult<Cluster> {
+    let args = manager::Cli {
+        config,
+        use_insecure_port: true,
+        ..Default::default()
+    };
+    Cluster::new(args)
 }
 
 trait IgnoreEexist {

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -8,7 +8,7 @@ mod tests {
     #[test]
     fn failover_partners() {
         let config_path = halo_lib::test_env::test_path("configs/lustre.yaml");
-        let cluster = halo_lib::cluster::Cluster::from_config(Some(config_path)).unwrap();
+        let cluster = halo_lib::test_env::cluster_from_config(Some(config_path)).unwrap();
 
         let first_host = cluster.hosts().next().unwrap();
         let first_host_partner = Arc::clone(first_host);

--- a/tests/usability.rs
+++ b/tests/usability.rs
@@ -45,6 +45,7 @@ mod tests {
         let invalid_socket = "bad_dir/socket";
         let result = std::process::Command::new(env!("CARGO_BIN_EXE_halo_manager"))
             .args(vec![
+                "--use-insecure-port",
                 "--config",
                 &good_config_path,
                 "--socket",


### PR DESCRIPTION
To strengthen the security boundary regarding access to remote agents, this PR adds
 - the`--allow-insecure-ports` option to the remote agent, allowing it to accept connection attempts from unprivileged ports; off by default
 - the `--use-insecure-port` option to the manager, allowing it to initiate connections to remote agents from an unprivileged port; off by default

These options will be helpful for situations where the management server has unprivileged users who can log into it who might try to fabricate RPCs to the remote agents. If the remote agents reject connections from unprivileged ports, this attack is prevented.

Closes #109