### PR TITLE
making fencing more robust to timeouts

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -100,6 +100,7 @@ fn get_http_client(socket_path: Option<&str>) -> HandledResult<reqwest::blocking
 
     let client = reqwest::blocking::ClientBuilder::new()
         .unix_socket(addr)
+        .timeout(None)
         .build()
         .handle_err(|e| eprintln!("Could not create HTTP client at {}: {}", addr, e))?;
 

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -367,10 +367,7 @@ impl Host {
             .take()
             .expect("Fence event must be set in order for admin fence request to be in progress.");
 
-        fence_event
-            .result
-            .send(res)
-            .expect("Sending on oneshot channel should not fail.");
+        let _ = fence_event.result.send(res);
     }
 
     async fn remote_liveness_check(&self, cluster: &Cluster) {


### PR DESCRIPTION
This disables the default HTTP client timeout of 30 seconds for the CLI utility's HTTP client.

This applies to all commands, but it's most important for fencing since it does happen that fencing takes longer than 30 seconds.

While the other commands are expected to complete quickly, they could be slow or future slow commands could be added in the future, so this disables the timeout for all commands.

In addition, the admin could interrupt the CLI utility after initiating a fence action, and in that case the result of the fence cannot be communicated back to the admin. To account for this possibility, the manager no longer considers it to be a fatal error if sending the fence result back fails.